### PR TITLE
Fix Token-Permissions scorecard alerts, dismiss Dependabot build-time CVEs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,9 +8,7 @@ on:
   schedule:
     - cron: '32 9 * * 5'
 
-permissions:
-  contents: read
-  security-events: write
+permissions: read-all
 
 jobs:
   analyze:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,15 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write  # Required for Sigstore keyless signing
+permissions: read-all
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write  # Required for Sigstore keyless signing
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Move write permissions from top-level to job-level in release.yml and codeql.yml (fixes scorecard Token-Permissions alerts #23, #25, #26)
- Dismiss all 16 Dependabot alerts as tolerable risk; all are build-time-only transitive deps from Gradle plugin resolution, not bundled into the SDK