### PR TITLE
Improve OpenSSF Scorecard: CODEOWNERS + SLSA provenance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pzverkov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       contents: write
       packages: write
       id-token: write  # Required for Sigstore keyless signing
+      attestations: write  # Required for SLSA provenance attestations
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -48,6 +49,11 @@ jobs:
               --output-signature "${file}.sig" \
               --output-certificate "${file}.pem"
           done
+
+      - name: Attest build provenance (SLSA)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: kiosk-ops-sdk/build/outputs/aar/*.aar
 
       - name: Publish to GitHub Packages
         run: ./gradlew :kiosk-ops-sdk:publishReleasePublicationToGitHubPackagesRepository -PVERSION_NAME=${{ steps.version.outputs.VERSION }}


### PR DESCRIPTION
## Summary
- Add CODEOWNERS file (improves Branch-Protection score)
- Add SLSA build provenance attestation via actions/attest-build-provenance to release workflow (improves Signed-Releases 8/10 to 10/10)