### PR TITLE
Add make_latest to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           body_path: release_notes.md
+          make_latest: true
           files: |
             kiosk-ops-sdk/build/outputs/aar/*.aar
             kiosk-ops-sdk/build/outputs/aar/*.sig


### PR DESCRIPTION
## Summary

- Add make_latest: true to softprops/action-gh-release step so the workflow creates releases compatible with immutable release rulesets