### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,7 +11,11 @@
 
 | Version | Supported |
 | ------- | --------- |
-| 0.x.x   | Yes       |
+| >= 0.5.x | Yes      |
+| < 0.5.0  | No       |
+
+Versions prior to 0.5.0 are not supported and will not receive security fixes.
+Please upgrade to the latest release.
 
 ## Reporting a Vulnerability
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-03-17
+
+Patch release with documentation and project governance updates.
+
+### Changed
+
+- Copyright holder updated to SARA STAR QUANT LLC across all source files and LICENSE
+- Added legal and security disclaimers to README, SECURITY.md, SECURITY_COMPLIANCE.md, FEATURES.md
+- Updated documentation with v0.5.0 feature coverage
+- Release workflow updated for immutable release compatibility
+- Branch protection enabled on main (PR reviews required, build status check)
+
+---
+
 ## [0.5.0] - 2026-03-17
 
 Data quality, compliance, and validation release targeting NGO and US federal (NIST 800-53 / FedRAMP / GDPR) deployments.
@@ -348,6 +362,7 @@ Initial release of KioskOps SDK for Android Enterprise.
 - Java 17+
 - Kotlin 2.1+
 
+[0.5.1]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.1
 [0.5.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.0
 [0.4.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.4.0
 [0.3.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.3.0

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.peterz.kioskops:kiosk-ops-sdk:0.5.0")
+    implementation("com.peterz.kioskops:kiosk-ops-sdk:0.5.1")
 }
 ```
 
@@ -55,7 +55,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.pzverkov:KioskOps-SDK-Android-Enterprise:v0.5.0")
+    implementation("com.github.pzverkov:KioskOps-SDK-Android-Enterprise:v0.5.1")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ android.useAndroidX=true
 kotlin.code.style=official
 
 # SDK Version
-VERSION_NAME=0.5.0-SNAPSHOT
+VERSION_NAME=0.5.1

--- a/kiosk-ops-sdk/src/main/java/com/peterz/kioskops/sdk/KioskOpsSdk.kt
+++ b/kiosk-ops-sdk/src/main/java/com/peterz/kioskops/sdk/KioskOpsSdk.kt
@@ -813,7 +813,7 @@ class KioskOpsSdk private constructor(
   }
 
   companion object {
-    const val SDK_VERSION = "0.5.0"
+    const val SDK_VERSION = "0.5.1"
 
     @Volatile private var INSTANCE: KioskOpsSdk? = null
 


### PR DESCRIPTION
## Summary

- Bump SDK_VERSION and VERSION_NAME to 0.5.1
- Update README installation examples to 0.5.1
- Add CHANGELOG entry for 0.5.1 (copyright, disclaimers, governance)
- Update SECURITY.md supported versions: >= 0.5.x only