### PR TITLE
Restructure release workflow for immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.5.1). Tag must already exist.'
+        required: true
+        type: string
 
 permissions: read-all
 
@@ -16,8 +19,28 @@ jobs:
       id-token: write  # Required for Sigstore keyless signing
       attestations: write  # Required for SLSA provenance attestations
     steps:
+      - name: Validate tag exists
+        run: |
+          git ls-remote --tags "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" "$TAG" | grep -q "$TAG" || {
+            echo "::error::Tag $TAG does not exist. Push the tag first."
+            exit 1
+          }
+        env:
+          TAG: ${{ inputs.tag }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${INPUT_TAG}"
+          echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
+          echo "TAG=${TAG}" >> $GITHUB_OUTPUT
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
@@ -27,10 +50,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
-
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
       - name: Build release AAR
         run: ./gradlew :kiosk-ops-sdk:assembleRelease -PVERSION_NAME=${{ steps.version.outputs.VERSION }}
@@ -62,19 +81,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate release notes
-        id: notes
         run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
+          VERSION="${INPUT_VERSION}"
           if grep -q "## \[${VERSION}\]" CHANGELOG.md; then
-            # Extract release notes from CHANGELOG.md
             sed -n "/## \[${VERSION}\]/,/## \[/p" CHANGELOG.md | sed '1d;$d' > release_notes.md
           else
             echo "Release ${VERSION}" > release_notes.md
           fi
+        env:
+          INPUT_VERSION: ${{ steps.version.outputs.VERSION }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
+          tag_name: ${{ steps.version.outputs.TAG }}
+          name: ${{ steps.version.outputs.TAG }}
           body_path: release_notes.md
           make_latest: true
           files: |
@@ -87,17 +108,20 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Release ${{ steps.version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Release ${VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
-          echo "- **GitHub Packages**: \`com.peterz.kioskops:kiosk-ops-sdk:${{ steps.version.outputs.VERSION }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **JitPack**: \`com.github.pzverkov:KioskOps-SDK-Android-Enterprise:${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **GitHub Packages**: \`com.peterz.kioskops:kiosk-ops-sdk:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **JitPack**: \`com.github.pzverkov:KioskOps-SDK-Android-Enterprise:${TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Signature Verification" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "cosign verify-blob kiosk-ops-sdk-release.aar \\\\" >> $GITHUB_STEP_SUMMARY
-          echo "  --signature kiosk-ops-sdk-release.aar.sig \\\\" >> $GITHUB_STEP_SUMMARY
-          echo "  --certificate kiosk-ops-sdk-release.aar.pem \\\\" >> $GITHUB_STEP_SUMMARY
-          echo "  --certificate-identity-regexp 'https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise' \\\\" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "cosign verify-blob kiosk-ops-sdk-release.aar \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --signature kiosk-ops-sdk-release.aar.sig \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --certificate kiosk-ops-sdk-release.aar.pem \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --certificate-identity-regexp 'https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise' \\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          TAG: ${{ steps.version.outputs.TAG }}


### PR DESCRIPTION
## Summary

- Change release workflow trigger from tag push to workflow_dispatch with tag input
- Workflow creates the release with all assets atomically; no pre-existing release to conflict with immutable lock
- New release flow: push tag, then trigger workflow from Actions tab with the tag name
- All steps use environment variables instead of inline expressions for safety