### PR TITLE
Fix jackson-core CVEs in Dokka build classpath

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -162,6 +162,7 @@ Focus: Java interop, error handling, observability, API contract finalization, f
 - [ ] Document sync ordering limitation (batches may arrive out of order under retry)
 
 ### Build Infrastructure
+- [ ] Dokka V1 -> V2 migration (eliminates vulnerable jackson-core, netty, woodstox transitive dependencies from build classpath)
 - [ ] Gradle Daemon toolchain (auto-detect/download JDK, align CLI and IDE, single Daemon)
 
 ### Supply Chain & Compliance

--- a/kiosk-ops-sdk/build.gradle.kts
+++ b/kiosk-ops-sdk/build.gradle.kts
@@ -13,6 +13,19 @@ kotlin {
   jvmToolchain(17)
 }
 
+// Force patched jackson for Dokka V1 build classpath (GHSA-h46c-h94j-95f3, GHSA-wf8f-6423-gfxg)
+// Remove after Dokka V2 migration in v0.7.0
+configurations.matching { it.name.startsWith("dokka") }.configureEach {
+  resolutionStrategy.eachDependency {
+    if (requested.group == "com.fasterxml.jackson.core") {
+      useVersion("2.15.4")
+    }
+    if (requested.group == "com.fasterxml.jackson.module") {
+      useVersion("2.15.4")
+    }
+  }
+}
+
 // Force patched jackson for Dokka's build-time classpath (GHSA-h46c-h94j-95f3)
 configurations.matching { it.name.startsWith("dokka") }.configureEach {
   resolutionStrategy.eachDependency {


### PR DESCRIPTION
## Summary

- Force jackson-core and jackson-module-kotlin to 2.15.4 on Dokka's build classpath, fixing GHSA-h46c-h94j-95f3 (StackOverflow) and GHSA-wf8f-6423-gfxg (memory disclosure)
- Add Dokka V1 -> V2 migration to v0.7.0 roadmap (eliminates the root cause; jackson, netty, woodstox transitive dependencies all come from Dokka V1)

## Context

Dokka V1 pulls jackson-core 2.12.7 transitively. This is build-time only (not shipped in the SDK AAR), but it triggers Dependabot high-severity alerts. The resolution strategy forces a patched version without breaking Dokka's API compatibility. The permanent fix is the Dokka V2 migration planned for v0.7.0.