### PR TITLE
Prepare v0.7.0 release docs

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -106,6 +106,12 @@ KioskOps SDK includes enterprise security features:
 - GDPR data export (Art. 20) and deletion (Art. 17) APIs
 - Data classification tagging (PUBLIC/INTERNAL/CONFIDENTIAL/RESTRICTED)
 
+### Error Observability & Supply Chain (v0.7.0)
+- Non-fatal error callbacks via `KioskOpsErrorListener` for operational visibility
+- FIPS 140-2/3 runtime detection via `FipsComplianceChecker` (Conscrypt/BoringSSL)
+- CycloneDX SBOM generation in CI for EO 14028 / FedRAMP supply chain requirements
+- Debug log level toggle restricted to debug builds (ISO 27001 A.14.2)
+
 ### Disclaimer
 
 References to regulatory frameworks (NIST 800-53, FedRAMP, GDPR, ISO 27001,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] - Unreleased
+## [0.7.0] - 2026-04-02
 
 Pre-1.0 hardening release; Java interop, error observability, supply chain compliance, and test coverage push.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ cd KioskOps-SDK-Android-Enterprise
 | Run Detekt (static analysis) | `./gradlew :kiosk-ops-sdk:detekt` |
 | Check API compatibility | `./gradlew apiCheck` |
 | Update API dump | `./gradlew apiDump` |
-| Generate API docs | `./gradlew :kiosk-ops-sdk:dokkaHtml` |
-| Generate coverage report | `./gradlew :kiosk-ops-sdk:jacocoTestReport` |
+| Generate API docs | `./gradlew :kiosk-ops-sdk:dokkaGeneratePublicationHtml` |
+| Generate coverage report | `./gradlew :kiosk-ops-sdk:koverHtmlReportDebug` |
 | Run all checks | `./gradlew check` |
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # KioskOps SDK for Android Enterprise
 
 [![Build](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/build.yml/badge.svg)](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/build.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-68%25-brightgreen.svg)](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/build.yml)
 [![CodeQL](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/codeql.yml/badge.svg)](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/codeql.yml)
 [![Fuzz](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/fuzz.yml/badge.svg)](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/fuzz.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/pzverkov/KioskOps-SDK-Android-Enterprise/badge)](https://securityscorecards.dev/viewer/?uri=github.com/pzverkov/KioskOps-SDK-Android-Enterprise)
 [![JitPack](https://jitpack.io/v/pzverkov/KioskOps-SDK-Android-Enterprise.svg)](https://jitpack.io/#pzverkov/KioskOps-SDK-Android-Enterprise)
 [![API](https://img.shields.io/badge/API-26%2B-brightgreen.svg)](https://android-arsenal.com/api?level=26)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.1-purple.svg)](https://kotlinlang.org/)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
-[![Java](https://img.shields.io/badge/Java-17-orange.svg)](https://openjdk.org/projects/jdk/17/)
 
 An **enterprise-grade Android SDK** for **offline-first operational events**, **local diagnostics**, and **fleet-friendly observability**. Designed for kiosk, retail, logistics, and field service deployments with **Samsung Knox / Android Enterprise** integration.
 
@@ -39,7 +40,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.peterz.kioskops:kiosk-ops-sdk:0.6.0")
+    implementation("com.peterz.kioskops:kiosk-ops-sdk:0.7.0")
 }
 ```
 
@@ -55,7 +56,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.pzverkov:KioskOps-SDK-Android-Enterprise:v0.6.0")
+    implementation("com.github.pzverkov:KioskOps-SDK-Android-Enterprise:v0.7.0")
 }
 ```
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -69,6 +69,17 @@
 | Debug overlay | Available | Data-only SDK state snapshot |
 | Performance profiler | Available | Operation timing for enqueue, validation, PII, etc. |
 
+### Observability & Java Interop (v0.7.0)
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| Health check | Available | Structured SDK health snapshot (queue, sync, auth, encryption) |
+| Error listener | Off | Non-fatal error callbacks via `setErrorListener()` |
+| Java interop | Available | Blocking wrappers returning `CompletableFuture`; `@JvmStatic`, `@JvmOverloads` |
+| Debug log toggle | Off | ADB broadcast to change log level at runtime (debug builds only) |
+| FIPS 140 detection | Available | Runtime check for FIPS-mode Conscrypt/BoringSSL provider |
+| SBOM | CI | CycloneDX BOM generated in CI pipeline |
+
 See [Security & Compliance](SECURITY_COMPLIANCE.md) for the full threat model.
 
 ## Fleet Operations


### PR DESCRIPTION
## Summary

- Replace Java badge with Kotlin 2.1; add Coverage 68% badge
- Update installation examples from v0.6.0 to v0.7.0 (GitHub Packages and JitPack)
- Set CHANGELOG date to 2026-04-02
- Fix stale CONTRIBUTING.md task names: JaCoCo to Kover, Dokka V1 to V2
- Add v0.7.0 sections to SECURITY.md (FIPS 140, error observability, SBOM) and FEATURES.md (health check, Java interop, debug log toggle)
