### PR TITLE
Fix build-time CVEs: upgrade CycloneDX plugin to 3.2.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ bcv = "0.16.3"
 dokka = "2.0.0"
 detekt = "1.23.7"
 kover = "0.9.1"
-cyclonedx = "2.2.0"
+cyclonedx = "3.2.3"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## Summary

- Upgrade CycloneDX Gradle plugin 2.2.0 to 3.2.3
- Fixes cyclonedx-core-java XXE injection (CVE-2025-64518, HIGH) by pulling core 11.0.1
- Fixes commons-lang3 uncontrolled recursion (CVE-2025-48924, MEDIUM) transitively via 3.19.0

## Remaining alerts (no action needed)

- **jackson-core #20, #21**: Dependabot false positives; resolved version is 2.20.1, well above both fix thresholds (2.13.0, 2.15.0).
- **plexus-utils #25**: Build-time transitive dep at 3.6.0 (fix: 4.0.3). Directory traversal in `extractFile` is not reachable during Gradle builds. Forcing a 3.x to 4.x major bump on a plugin transitive dep risks breaking the build with no security benefit.
