### PR TITLE
Maven Central publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,15 +74,34 @@ jobs:
         with:
           subject-path: kiosk-ops-sdk/build/outputs/aar/*.aar
 
+      - name: Generate docs for Javadoc JAR
+        run: ./gradlew :kiosk-ops-sdk:dokkaGeneratePublicationHtml -PVERSION_NAME="$VERSION" --no-configuration-cache
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+
+      - name: Publish to Maven Central
+        run: |
+          ./gradlew :kiosk-ops-sdk:publishReleasePublicationToMavenCentralRepository -PVERSION_NAME="$VERSION" || {
+            echo "::warning::Maven Central publish failed. Continuing."
+          }
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+
       - name: Publish to GitHub Packages
         run: |
           ./gradlew :kiosk-ops-sdk:publishReleasePublicationToGitHubPackagesRepository -PVERSION_NAME="$VERSION" || {
-            echo "::warning::Publish failed (version may already exist). Continuing."
+            echo "::warning::GitHub Packages publish failed (version may already exist). Continuing."
           }
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
 
       - name: Generate release notes
         run: |
@@ -113,6 +132,7 @@ jobs:
           echo "## Release ${VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
+          echo "- **Maven Central**: \`com.sarastarquant.kioskops:kiosk-ops-sdk:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **GitHub Packages**: \`com.sarastarquant.kioskops:kiosk-ops-sdk:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **JitPack**: \`com.github.pzverkov:KioskOps-SDK-Android-Enterprise:${TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/kiosk-ops-sdk/build.gradle.kts
+++ b/kiosk-ops-sdk/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.kover)
   alias(libs.plugins.cyclonedx)
   `maven-publish`
+  signing
 }
 
 kotlin {
@@ -150,7 +151,19 @@ dependencies {
   testImplementation(libs.jazzer.junit)
 }
 
-// Publishing configuration for GitHub Packages and JitPack
+// Sources and Javadoc JARs (required by Maven Central)
+val sourcesJar by tasks.registering(Jar::class) {
+  archiveClassifier.set("sources")
+  from(android.sourceSets["main"].java.srcDirs)
+}
+
+val javadocJar by tasks.registering(Jar::class) {
+  archiveClassifier.set("javadoc")
+  dependsOn(tasks.named("dokkaGeneratePublicationHtml"))
+  from(layout.buildDirectory.dir("dokka/html"))
+}
+
+// Publishing configuration for Maven Central, GitHub Packages, and JitPack
 afterEvaluate {
   publishing {
     publications {
@@ -160,6 +173,9 @@ afterEvaluate {
         groupId = "com.sarastarquant.kioskops"
         artifactId = "kiosk-ops-sdk"
         version = findProperty("VERSION_NAME")?.toString() ?: "0.1.0-SNAPSHOT"
+
+        artifact(sourcesJar)
+        artifact(javadocJar)
 
         pom {
           name.set("KioskOps SDK")
@@ -177,6 +193,7 @@ afterEvaluate {
             developer {
               id.set("pzverkov")
               name.set("Petro Zverkov")
+              organization.set("Sara Star Quant LLC")
             }
           }
 
@@ -198,6 +215,23 @@ afterEvaluate {
           password = System.getenv("GITHUB_TOKEN") ?: findProperty("gpr.token")?.toString()
         }
       }
+      maven {
+        name = "MavenCentral"
+        url = uri("https://central.sonatype.com/api/v1/publisher/deployments/download/")
+        credentials {
+          username = System.getenv("MAVEN_CENTRAL_USERNAME") ?: findProperty("mavenCentral.username")?.toString()
+          password = System.getenv("MAVEN_CENTRAL_PASSWORD") ?: findProperty("mavenCentral.password")?.toString()
+        }
+      }
+    }
+  }
+
+  signing {
+    val signingKey = System.getenv("GPG_SIGNING_KEY")
+    val signingPassword = System.getenv("GPG_SIGNING_PASSWORD")
+    if (signingKey != null && signingPassword != null) {
+      useInMemoryPgpKeys(signingKey, signingPassword)
+      sign(publishing.publications["release"])
     }
   }
 }


### PR DESCRIPTION
## Summary

- Maven Central publication via Sonatype Central Portal
- GPG signing with in-memory key from CI secrets
- Sources JAR and Javadoc JAR (Dokka output) included in publication
- Release workflow publishes to Maven Central before GitHub Packages
- Release summary includes Maven Central coordinates
