### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.0] - 2026-04-02
+## [0.9.0] - 2026-04-04
 
 Lifecycle-aware telemetry, reactive config updates, global PII patterns, anomaly baseline seeding, instrumented tests, and Maven Central publication.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:0.8.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:0.9.0")
 }
 ```
 
@@ -56,7 +56,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:0.8.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:0.9.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ kotlin.code.style=official
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 # SDK Version
-VERSION_NAME=0.8.0
+VERSION_NAME=0.9.0


### PR DESCRIPTION
## Summary

- Bump VERSION_NAME to 0.9.0
- Update README installation examples to 0.9.0
- Update CHANGELOG release date
