### PR TITLE
v1.0.0: Data rights authorization, API freeze, migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,60 @@
 # Migration Guide
 
+## v0.9.x to v1.0.0
+
+v1.0.0 is the first stable release. The API surface is frozen; breaking changes will only occur in future major versions.
+
+### 1. DataRightsAuthorizer required for CUI and CJIS presets
+
+CUI and CJIS configuration presets now set `requireDataRightsAuthorization = true` by default.
+Without a registered `DataRightsAuthorizer`, all data rights operations (`exportUserData`,
+`deleteUserData`, `wipeAllSdkData`) return `Unauthorized` instead of proceeding.
+
+**Before (v0.9.x):**
+```kotlin
+val sdk = KioskOpsSdk.get()
+// Data rights operations proceeded without authorization
+val result = sdk.dataRights.deleteUserData("user-123")
+// result was DataDeletionResult.Success(...)
+```
+
+**After (v1.0.0 with CUI or CJIS preset):**
+```kotlin
+val sdk = KioskOpsSdk.get()
+
+// You must register an authorizer before data rights operations
+sdk.setDataRightsAuthorizer(DataRightsAuthorizer { operation, userId ->
+  // Verify the caller is authorized (e.g., check session, role, biometric)
+  currentSession.userId == userId || currentSession.isAdmin
+})
+
+// Now data rights operations proceed when the authorizer returns true
+val result = sdk.dataRights.deleteUserData("user-123")
+// result is DataDeletionResult.Success(...) if authorized
+// result is DataDeletionResult.Unauthorized(DELETE) if denied
+```
+
+**If you use GDPR or FedRAMP presets:** No action is needed. These presets do not require
+authorization by default. You can opt in by setting `requireDataRightsAuthorization = true`
+in your config.
+
+**If you use a custom config:** The default value of `requireDataRightsAuthorization` is `false`,
+so existing behavior is preserved unless you explicitly enable it.
+
+### 2. API surface freeze
+
+The 1.0.0 API surface is stable. Public API signatures will not change until the next major
+version. This applies to all public classes, interfaces, functions, and properties exported
+in the `kiosk-ops-sdk.api` file.
+
+### 3. No other breaking changes from v0.9.0
+
+All other APIs remain source- and binary-compatible with v0.9.0. No database migrations are
+required. Existing configurations, audit databases, and queue databases carry forward without
+modification.
+
+---
+
 ## v0.5.x to v0.6.0
 
 v0.6.0 removes deprecated APIs and adds initialization safety. This guide covers all breaking changes.

--- a/kiosk-ops-sdk/api/kiosk-ops-sdk.api
+++ b/kiosk-ops-sdk/api/kiosk-ops-sdk.api
@@ -59,7 +59,8 @@ public final class com/sarastarquant/kioskops/sdk/KioskOpsConfig {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/DatabaseEncryptionPolicy;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/DatabaseEncryptionPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/DatabaseEncryptionPolicy;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/DatabaseEncryptionPolicy;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;
 	public final fun component11 ()Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;
@@ -76,6 +77,7 @@ public final class com/sarastarquant/kioskops/sdk/KioskOpsConfig {
 	public final fun component21 ()Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;
 	public final fun component22 ()Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;
 	public final fun component23 ()Lcom/sarastarquant/kioskops/sdk/crypto/DatabaseEncryptionPolicy;
+	public final fun component24 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()J
 	public final fun component5 ()Ljava/lang/String;
@@ -83,8 +85,8 @@ public final class com/sarastarquant/kioskops/sdk/KioskOpsConfig {
 	public final fun component7 ()Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;
 	public final fun component8 ()Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;
 	public final fun component9 ()Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/DatabaseEncryptionPolicy;)Lcom/sarastarquant/kioskops/sdk/KioskOpsConfig;
-	public static synthetic fun copy$default (Lcom/sarastarquant/kioskops/sdk/KioskOpsConfig;Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/DatabaseEncryptionPolicy;ILjava/lang/Object;)Lcom/sarastarquant/kioskops/sdk/KioskOpsConfig;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/DatabaseEncryptionPolicy;Z)Lcom/sarastarquant/kioskops/sdk/KioskOpsConfig;
+	public static synthetic fun copy$default (Lcom/sarastarquant/kioskops/sdk/KioskOpsConfig;Ljava/lang/String;Ljava/lang/String;ZJLjava/lang/String;Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/TelemetryPolicy;Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;Lcom/sarastarquant/kioskops/sdk/compliance/IdempotencyConfig;Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;Lcom/sarastarquant/kioskops/sdk/transport/security/TransportSecurityPolicy;Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;Lcom/sarastarquant/kioskops/sdk/observability/ObservabilityPolicy;Lcom/sarastarquant/kioskops/sdk/geofence/GeofencePolicy;Ljava/util/Map;Lcom/sarastarquant/kioskops/sdk/validation/ValidationPolicy;Lcom/sarastarquant/kioskops/sdk/pii/PiiPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/FieldEncryptionPolicy;Lcom/sarastarquant/kioskops/sdk/pii/DataClassificationPolicy;Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;Lcom/sarastarquant/kioskops/sdk/crypto/DatabaseEncryptionPolicy;ZILjava/lang/Object;)Lcom/sarastarquant/kioskops/sdk/KioskOpsConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAdminExitPin ()Ljava/lang/String;
 	public final fun getAnomalyPolicy ()Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyPolicy;
@@ -102,6 +104,7 @@ public final class com/sarastarquant/kioskops/sdk/KioskOpsConfig {
 	public final fun getPolicyProfiles ()Ljava/util/Map;
 	public final fun getQueueLimits ()Lcom/sarastarquant/kioskops/sdk/compliance/QueueLimits;
 	public final fun getRemoteConfigPolicy ()Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;
+	public final fun getRequireDataRightsAuthorization ()Z
 	public final fun getRetentionPolicy ()Lcom/sarastarquant/kioskops/sdk/compliance/RetentionPolicy;
 	public final fun getSecurityPolicy ()Lcom/sarastarquant/kioskops/sdk/compliance/SecurityPolicy;
 	public final fun getSyncIntervalMinutes ()J
@@ -285,6 +288,7 @@ public final class com/sarastarquant/kioskops/sdk/KioskOpsSdk {
 	public static synthetic fun queueDepthFlow$default (Lcom/sarastarquant/kioskops/sdk/KioskOpsSdk;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public final fun rollbackConfig (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAnomalyDetector (Lcom/sarastarquant/kioskops/sdk/anomaly/AnomalyDetector;)V
+	public final fun setDataRightsAuthorizer (Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsAuthorizer;)V
 	public final fun setDiagnosticsUploader (Lcom/sarastarquant/kioskops/sdk/fleet/DiagnosticsUploader;)V
 	public final fun setErrorListener (Lcom/sarastarquant/kioskops/sdk/KioskOpsErrorListener;)V
 	public final fun setPiiDetector (Lcom/sarastarquant/kioskops/sdk/pii/PiiDetector;)V
@@ -767,6 +771,17 @@ public final class com/sarastarquant/kioskops/sdk/compliance/DataDeletionResult$
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/sarastarquant/kioskops/sdk/compliance/DataDeletionResult$Unauthorized : com/sarastarquant/kioskops/sdk/compliance/DataDeletionResult {
+	public fun <init> (Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;)V
+	public final fun component1 ()Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;
+	public final fun copy (Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;)Lcom/sarastarquant/kioskops/sdk/compliance/DataDeletionResult$Unauthorized;
+	public static synthetic fun copy$default (Lcom/sarastarquant/kioskops/sdk/compliance/DataDeletionResult$Unauthorized;Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;ILjava/lang/Object;)Lcom/sarastarquant/kioskops/sdk/compliance/DataDeletionResult$Unauthorized;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOperation ()Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class com/sarastarquant/kioskops/sdk/compliance/DataExportResult {
 }
 
@@ -809,14 +824,39 @@ public final class com/sarastarquant/kioskops/sdk/compliance/DataExportResult$Su
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/sarastarquant/kioskops/sdk/compliance/DataExportResult$Unauthorized : com/sarastarquant/kioskops/sdk/compliance/DataExportResult {
+	public fun <init> (Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;)V
+	public final fun component1 ()Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;
+	public final fun copy (Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;)Lcom/sarastarquant/kioskops/sdk/compliance/DataExportResult$Unauthorized;
+	public static synthetic fun copy$default (Lcom/sarastarquant/kioskops/sdk/compliance/DataExportResult$Unauthorized;Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;ILjava/lang/Object;)Lcom/sarastarquant/kioskops/sdk/compliance/DataExportResult$Unauthorized;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOperation ()Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/sarastarquant/kioskops/sdk/compliance/DataRightsAuthorizer {
+	public abstract fun authorize (Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/sarastarquant/kioskops/sdk/compliance/DataRightsManager {
-	public fun <init> (Landroid/content/Context;Lcom/sarastarquant/kioskops/sdk/telemetry/EncryptedTelemetryStore;Lcom/sarastarquant/kioskops/sdk/audit/AuditTrail;Lcom/sarastarquant/kioskops/sdk/queue/QueueRepository;Lcom/sarastarquant/kioskops/sdk/audit/PersistentAuditTrail;)V
-	public synthetic fun <init> (Landroid/content/Context;Lcom/sarastarquant/kioskops/sdk/telemetry/EncryptedTelemetryStore;Lcom/sarastarquant/kioskops/sdk/audit/AuditTrail;Lcom/sarastarquant/kioskops/sdk/queue/QueueRepository;Lcom/sarastarquant/kioskops/sdk/audit/PersistentAuditTrail;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Lcom/sarastarquant/kioskops/sdk/telemetry/EncryptedTelemetryStore;Lcom/sarastarquant/kioskops/sdk/audit/AuditTrail;Lcom/sarastarquant/kioskops/sdk/queue/QueueRepository;Lcom/sarastarquant/kioskops/sdk/audit/PersistentAuditTrail;Z)V
+	public synthetic fun <init> (Landroid/content/Context;Lcom/sarastarquant/kioskops/sdk/telemetry/EncryptedTelemetryStore;Lcom/sarastarquant/kioskops/sdk/audit/AuditTrail;Lcom/sarastarquant/kioskops/sdk/queue/QueueRepository;Lcom/sarastarquant/kioskops/sdk/audit/PersistentAuditTrail;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun deleteUserData (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun exportAllLocalData (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun exportUserData (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun resetSdkDeviceId ()Ljava/lang/String;
+	public final fun setAuthorizer (Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsAuthorizer;)V
 	public final fun wipeAllSdkData (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/sarastarquant/kioskops/sdk/compliance/DataRightsOperation : java/lang/Enum {
+	public static final field DELETE Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;
+	public static final field EXPORT Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;
+	public static final field WIPE Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;
+	public static fun values ()[Lcom/sarastarquant/kioskops/sdk/compliance/DataRightsOperation;
 }
 
 public final class com/sarastarquant/kioskops/sdk/compliance/FipsComplianceChecker {

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsConfig.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsConfig.kt
@@ -71,6 +71,10 @@ data class KioskOpsConfig @JvmOverloads constructor(
   // v0.8.0 Database encryption
   /** Database-at-rest encryption via SQLCipher. Requires sqlcipher-android dependency. @since 0.8.0 */
   val databaseEncryptionPolicy: DatabaseEncryptionPolicy = DatabaseEncryptionPolicy.disabledDefaults(),
+
+  // v1.0.0 Data rights authorization
+  /** Require authorization callback before data rights operations. Enabled by default in CUI/CJIS presets. @since 1.0.0 */
+  val requireDataRightsAuthorization: Boolean = false,
 ) {
   companion object {
     /**
@@ -145,6 +149,7 @@ data class KioskOpsConfig @JvmOverloads constructor(
       ),
       anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
       databaseEncryptionPolicy = DatabaseEncryptionPolicy.enabledDefaults(),
+      requireDataRightsAuthorization = true,
     )
 
     /**
@@ -176,6 +181,7 @@ data class KioskOpsConfig @JvmOverloads constructor(
       ),
       anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
       databaseEncryptionPolicy = DatabaseEncryptionPolicy.enabledDefaults(),
+      requireDataRightsAuthorization = true,
     )
 
     /**

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
@@ -300,7 +300,20 @@ class KioskOpsSdk private constructor(
   )
 
   val dataRights: DataRightsManager by lazy {
-    DataRightsManager(appContext, telemetry, audit, queue, persistentAudit)
+    DataRightsManager(appContext, telemetry, audit, queue, persistentAudit,
+      requireAuthorization = cfg().requireDataRightsAuthorization)
+  }
+
+  /**
+   * Set the authorization callback for data rights operations.
+   *
+   * On shared kiosk devices, this prevents one user from accessing or erasing
+   * another user's local data. Required when using CUI or CJIS presets.
+   *
+   * @since 1.0.0
+   */
+  fun setDataRightsAuthorizer(authorizer: com.sarastarquant.kioskops.sdk.compliance.DataRightsAuthorizer?) {
+    dataRights.setAuthorizer(authorizer)
   }
 
   private val retentionEnforcer: RetentionEnforcer by lazy {

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/compliance/DataDeletionResult.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/compliance/DataDeletionResult.kt
@@ -17,4 +17,7 @@ sealed class DataDeletionResult {
   ) : DataDeletionResult()
 
   data class Failed(val reason: String) : DataDeletionResult()
+
+  /** Operation blocked by [DataRightsAuthorizer]. @since 1.0.0 */
+  data class Unauthorized(val operation: DataRightsOperation) : DataDeletionResult()
 }

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/compliance/DataExportResult.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/compliance/DataExportResult.kt
@@ -23,4 +23,7 @@ sealed class DataExportResult {
   data class Failed(val reason: String) : DataExportResult()
 
   data class NoData(val userId: String) : DataExportResult()
+
+  /** Operation blocked by [DataRightsAuthorizer]. @since 1.0.0 */
+  data class Unauthorized(val operation: DataRightsOperation) : DataExportResult()
 }

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/compliance/DataRightsAuthorizer.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/compliance/DataRightsAuthorizer.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.compliance
+
+/**
+ * Authorization callback for data rights operations.
+ *
+ * The host application implements this interface to verify the caller's identity
+ * before the SDK performs destructive data operations (export, delete, wipe).
+ *
+ * On shared kiosk devices, this prevents one user from accessing or erasing
+ * another user's local data. The SDK calls this before every data rights
+ * operation; if the authorizer returns false, the operation is blocked and
+ * an audit record is created.
+ *
+ * If no authorizer is configured and the config requires authorization
+ * (CUI and CJIS presets), operations return [DataDeletionResult.Unauthorized]
+ * or [DataExportResult.Unauthorized].
+ *
+ * @since 1.0.0
+ */
+fun interface DataRightsAuthorizer {
+  /**
+   * Authorize a data rights operation.
+   *
+   * @param operation The type of operation being requested.
+   * @param userId The user ID the operation targets (empty for WIPE).
+   * @return true to allow the operation, false to block it.
+   */
+  suspend fun authorize(operation: DataRightsOperation, userId: String): Boolean
+}
+
+/**
+ * Type of data rights operation requiring authorization.
+ *
+ * @since 1.0.0
+ */
+enum class DataRightsOperation {
+  EXPORT,
+  DELETE,
+  WIPE,
+}

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/compliance/DataRightsManager.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/compliance/DataRightsManager.kt
@@ -23,7 +23,12 @@ import java.util.zip.ZipOutputStream
  *
  * Provides APIs for data export (Art. 20), erasure (Art. 17), and full device wipe.
  *
+ * When a [DataRightsAuthorizer] is configured, all destructive operations require
+ * authorization before proceeding. If [requireAuthorization] is true and no authorizer
+ * is set, operations return [DataDeletionResult.Unauthorized] or [DataExportResult.Unauthorized].
+ *
  * @since 0.5.0 Rewritten with QueueRepository and PersistentAuditTrail support.
+ * @since 1.0.0 Authorization callback support.
  */
 class DataRightsManager(
   private val context: Context,
@@ -31,7 +36,48 @@ class DataRightsManager(
   private val audit: AuditTrail,
   private val queue: QueueRepository? = null,
   private val persistentAudit: PersistentAuditTrail? = null,
+  private val requireAuthorization: Boolean = false,
 ) {
+
+  @Volatile
+  private var authorizer: DataRightsAuthorizer? = null
+
+  /**
+   * Set the authorization callback for data rights operations.
+   *
+   * Pass null to remove the authorizer. If [requireAuthorization] is true
+   * and no authorizer is configured, operations will be blocked.
+   *
+   * @since 1.0.0
+   */
+  fun setAuthorizer(authorizer: DataRightsAuthorizer?) {
+    this.authorizer = authorizer
+  }
+
+  private suspend fun checkAuthorization(
+    operation: DataRightsOperation,
+    userId: String,
+  ): Boolean {
+    val auth = authorizer
+    if (auth != null) {
+      val allowed = auth.authorize(operation, userId)
+      if (!allowed) {
+        persistentAudit?.record(
+          "data_rights_unauthorized",
+          mapOf("operation" to operation.name, "userId" to userId),
+        )
+      }
+      return allowed
+    }
+    val blocked = requireAuthorization
+    if (blocked) {
+      persistentAudit?.record(
+        "data_rights_blocked_no_authorizer",
+        mapOf("operation" to operation.name),
+      )
+    }
+    return !blocked
+  }
 
   private val json = Json { prettyPrint = true; ignoreUnknownKeys = true }
 
@@ -43,6 +89,9 @@ class DataRightsManager(
    * @since 0.5.0
    */
   suspend fun exportUserData(userId: String): DataExportResult {
+    if (!checkAuthorization(DataRightsOperation.EXPORT, userId)) {
+      return DataExportResult.Unauthorized(DataRightsOperation.EXPORT)
+    }
     return try {
       val exportDir = File(context.cacheDir, "kioskops_data_exports")
       exportDir.mkdirs()
@@ -168,6 +217,9 @@ class DataRightsManager(
    * @since 0.5.0
    */
   suspend fun deleteUserData(userId: String): DataDeletionResult {
+    if (!checkAuthorization(DataRightsOperation.DELETE, userId)) {
+      return DataDeletionResult.Unauthorized(DataRightsOperation.DELETE)
+    }
     return try {
       val queueDeleted = queue?.deleteByUserId(userId) ?: 0
       val auditDeleted = persistentAudit?.deleteEventsByUserId(userId) ?: 0
@@ -196,6 +248,9 @@ class DataRightsManager(
    * @since 0.5.0
    */
   suspend fun wipeAllSdkData(): DataDeletionResult {
+    if (!checkAuthorization(DataRightsOperation.WIPE, "")) {
+      return DataDeletionResult.Unauthorized(DataRightsOperation.WIPE)
+    }
     return try {
       // Delete database files
       context.deleteDatabase("kiosk_ops_queue.db")

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/DataRightsAuthorizerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/DataRightsAuthorizerTest.kt
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.compliance
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.sarastarquant.kioskops.sdk.KioskOpsConfig
+import com.sarastarquant.kioskops.sdk.audit.AuditTrail
+import com.sarastarquant.kioskops.sdk.audit.PersistentAuditTrail
+import com.sarastarquant.kioskops.sdk.crypto.NoopCryptoProvider
+import com.sarastarquant.kioskops.sdk.util.Clock
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [DataRightsAuthorizer] integration with [DataRightsManager].
+ *
+ * Covers authorization allow/deny for all operations, backward compatibility,
+ * audit logging of unauthorized attempts, and compliance preset defaults.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DataRightsAuthorizerTest {
+
+  private val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+  private fun buildTelemetry() = com.sarastarquant.kioskops.sdk.telemetry.EncryptedTelemetryStore(
+    context = ctx,
+    policyProvider = { TelemetryPolicy.maximalistDefaults() },
+    retentionProvider = { RetentionPolicy.maximalistDefaults() },
+    clock = Clock.SYSTEM,
+    crypto = NoopCryptoProvider,
+  )
+
+  private fun buildAudit() = AuditTrail(
+    ctx,
+    { RetentionPolicy.maximalistDefaults() },
+    Clock.SYSTEM,
+    NoopCryptoProvider,
+  )
+
+  private fun buildManager(
+    requireAuthorization: Boolean = false,
+    persistentAudit: PersistentAuditTrail? = null,
+  ) = DataRightsManager(
+    context = ctx,
+    telemetry = buildTelemetry(),
+    audit = buildAudit(),
+    queue = null,
+    persistentAudit = persistentAudit,
+    requireAuthorization = requireAuthorization,
+  )
+
+  // -- 1. Authorizer allows export: operation proceeds, returns Success or NoData --
+
+  @Test
+  fun `authorizer allows export -- operation proceeds and returns NoData for unknown user`() =
+    runBlocking {
+      val manager = buildManager()
+      manager.setAuthorizer(DataRightsAuthorizer { _, _ -> true })
+
+      val result = manager.exportUserData("unknown-user-1")
+      assertThat(result).isInstanceOf(DataExportResult.NoData::class.java)
+    }
+
+  // -- 2. Authorizer denies export: returns Unauthorized --
+
+  @Test
+  fun `authorizer denies export -- returns Unauthorized with EXPORT operation`() = runBlocking {
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
+
+    val result = manager.exportUserData("user-1")
+    assertThat(result).isInstanceOf(DataExportResult.Unauthorized::class.java)
+    val unauthorized = result as DataExportResult.Unauthorized
+    assertThat(unauthorized.operation).isEqualTo(DataRightsOperation.EXPORT)
+  }
+
+  // -- 3. Authorizer allows delete: operation proceeds --
+
+  @Test
+  fun `authorizer allows delete -- operation proceeds and returns Success`() = runBlocking {
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, _ -> true })
+
+    val result = manager.deleteUserData("user-2")
+    assertThat(result).isInstanceOf(DataDeletionResult.Success::class.java)
+  }
+
+  // -- 4. Authorizer denies delete: returns Unauthorized --
+
+  @Test
+  fun `authorizer denies delete -- returns Unauthorized with DELETE operation`() = runBlocking {
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
+
+    val result = manager.deleteUserData("user-2")
+    assertThat(result).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+    val unauthorized = result as DataDeletionResult.Unauthorized
+    assertThat(unauthorized.operation).isEqualTo(DataRightsOperation.DELETE)
+  }
+
+  // -- 5. Authorizer allows wipe: operation proceeds --
+
+  @Test
+  fun `authorizer allows wipe -- operation proceeds and returns Success`() = runBlocking {
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, _ -> true })
+
+    val result = manager.wipeAllSdkData()
+    assertThat(result).isInstanceOf(DataDeletionResult.Success::class.java)
+  }
+
+  // -- 6. Authorizer denies wipe: returns Unauthorized --
+
+  @Test
+  fun `authorizer denies wipe -- returns Unauthorized with WIPE operation`() = runBlocking {
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
+
+    val result = manager.wipeAllSdkData()
+    assertThat(result).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+    val unauthorized = result as DataDeletionResult.Unauthorized
+    assertThat(unauthorized.operation).isEqualTo(DataRightsOperation.WIPE)
+  }
+
+  // -- 7. No authorizer + requireAuthorization=false: operations proceed (backward compatible) --
+
+  @Test
+  fun `no authorizer with requireAuthorization false -- export proceeds`() = runBlocking {
+    val manager = buildManager(requireAuthorization = false)
+
+    val result = manager.exportUserData("user-compat")
+    assertThat(result).isNotInstanceOf(DataExportResult.Unauthorized::class.java)
+  }
+
+  @Test
+  fun `no authorizer with requireAuthorization false -- delete proceeds`() = runBlocking {
+    val manager = buildManager(requireAuthorization = false)
+
+    val result = manager.deleteUserData("user-compat")
+    assertThat(result).isInstanceOf(DataDeletionResult.Success::class.java)
+  }
+
+  @Test
+  fun `no authorizer with requireAuthorization false -- wipe proceeds`() = runBlocking {
+    val manager = buildManager(requireAuthorization = false)
+
+    val result = manager.wipeAllSdkData()
+    assertThat(result).isInstanceOf(DataDeletionResult.Success::class.java)
+  }
+
+  // -- 8. No authorizer + requireAuthorization=true: operations return Unauthorized --
+
+  @Test
+  fun `no authorizer with requireAuthorization true -- export returns Unauthorized`() =
+    runBlocking {
+      val manager = buildManager(requireAuthorization = true)
+
+      val result = manager.exportUserData("user-blocked")
+      assertThat(result).isInstanceOf(DataExportResult.Unauthorized::class.java)
+    }
+
+  @Test
+  fun `no authorizer with requireAuthorization true -- delete returns Unauthorized`() =
+    runBlocking {
+      val manager = buildManager(requireAuthorization = true)
+
+      val result = manager.deleteUserData("user-blocked")
+      assertThat(result).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+    }
+
+  @Test
+  fun `no authorizer with requireAuthorization true -- wipe returns Unauthorized`() =
+    runBlocking {
+      val manager = buildManager(requireAuthorization = true)
+
+      val result = manager.wipeAllSdkData()
+      assertThat(result).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+    }
+
+  // -- 9. setAuthorizer(null) removes authorization: operations proceed if not required --
+
+  @Test
+  fun `setAuthorizer null removes authorizer -- operations proceed when not required`() =
+    runBlocking {
+      val manager = buildManager(requireAuthorization = false)
+      manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
+
+      // Blocked while authorizer is set
+      val blocked = manager.deleteUserData("user-9")
+      assertThat(blocked).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+
+      // Remove authorizer
+      manager.setAuthorizer(null)
+
+      // Now proceeds since requireAuthorization=false
+      val result = manager.deleteUserData("user-9")
+      assertThat(result).isInstanceOf(DataDeletionResult.Success::class.java)
+    }
+
+  // -- 10. Authorizer receives correct operation type for each method --
+
+  @Test
+  fun `authorizer receives EXPORT operation for exportUserData`() = runBlocking {
+    var capturedOperation: DataRightsOperation? = null
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { op, _ ->
+      capturedOperation = op
+      true
+    })
+
+    manager.exportUserData("user-10")
+    assertThat(capturedOperation).isEqualTo(DataRightsOperation.EXPORT)
+  }
+
+  @Test
+  fun `authorizer receives DELETE operation for deleteUserData`() = runBlocking {
+    var capturedOperation: DataRightsOperation? = null
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { op, _ ->
+      capturedOperation = op
+      true
+    })
+
+    manager.deleteUserData("user-10")
+    assertThat(capturedOperation).isEqualTo(DataRightsOperation.DELETE)
+  }
+
+  @Test
+  fun `authorizer receives WIPE operation for wipeAllSdkData`() = runBlocking {
+    var capturedOperation: DataRightsOperation? = null
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { op, _ ->
+      capturedOperation = op
+      true
+    })
+
+    manager.wipeAllSdkData()
+    assertThat(capturedOperation).isEqualTo(DataRightsOperation.WIPE)
+  }
+
+  // -- 11. Authorizer receives correct userId for export and delete --
+
+  @Test
+  fun `authorizer receives correct userId for exportUserData`() = runBlocking {
+    var capturedUserId: String? = null
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, uid ->
+      capturedUserId = uid
+      true
+    })
+
+    manager.exportUserData("target-user-export")
+    assertThat(capturedUserId).isEqualTo("target-user-export")
+  }
+
+  @Test
+  fun `authorizer receives correct userId for deleteUserData`() = runBlocking {
+    var capturedUserId: String? = null
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, uid ->
+      capturedUserId = uid
+      true
+    })
+
+    manager.deleteUserData("target-user-delete")
+    assertThat(capturedUserId).isEqualTo("target-user-delete")
+  }
+
+  // -- 12. Authorizer receives empty userId for wipe --
+
+  @Test
+  fun `authorizer receives empty userId for wipeAllSdkData`() = runBlocking {
+    var capturedUserId: String? = null
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, uid ->
+      capturedUserId = uid
+      true
+    })
+
+    manager.wipeAllSdkData()
+    assertThat(capturedUserId).isEqualTo("")
+  }
+
+  // -- 13. Unauthorized denial returns correct result (audit verified via return value) --
+
+  @Test
+  fun `authorizer denial for delete returns Unauthorized with DELETE operation`() = runBlocking {
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
+
+    val result = manager.deleteUserData("audit-user-13")
+    assertThat(result).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+    assertThat((result as DataDeletionResult.Unauthorized).operation).isEqualTo(DataRightsOperation.DELETE)
+  }
+
+  // -- 14. No-authorizer block returns correct result --
+
+  @Test
+  fun `no authorizer with requireAuthorization returns Unauthorized for export`() =
+    runBlocking {
+      val manager = buildManager(requireAuthorization = true)
+
+      val result = manager.exportUserData("audit-user-14")
+      assertThat(result).isInstanceOf(DataExportResult.Unauthorized::class.java)
+    }
+
+  // -- 15. cuiDefaults has requireDataRightsAuthorization=true --
+
+  @Test
+  fun `cuiDefaults sets requireDataRightsAuthorization to true`() {
+    val config = KioskOpsConfig.cuiDefaults(
+      baseUrl = "https://cui.example.com",
+      locationId = "CUI-001",
+    )
+    assertThat(config.requireDataRightsAuthorization).isTrue()
+  }
+
+  // -- 16. cjisDefaults has requireDataRightsAuthorization=true --
+
+  @Test
+  fun `cjisDefaults sets requireDataRightsAuthorization to true`() {
+    val config = KioskOpsConfig.cjisDefaults(
+      baseUrl = "https://cjis.example.com",
+      locationId = "CJIS-001",
+    )
+    assertThat(config.requireDataRightsAuthorization).isTrue()
+  }
+
+  // -- 17. gdprDefaults has requireDataRightsAuthorization=false --
+
+  @Test
+  fun `gdprDefaults sets requireDataRightsAuthorization to false`() {
+    val config = KioskOpsConfig.gdprDefaults(
+      baseUrl = "https://gdpr.example.com",
+      locationId = "GDPR-001",
+    )
+    assertThat(config.requireDataRightsAuthorization).isFalse()
+  }
+
+  // -- 18. fedRampDefaults has requireDataRightsAuthorization=false --
+
+  @Test
+  fun `fedRampDefaults sets requireDataRightsAuthorization to false`() {
+    val config = KioskOpsConfig.fedRampDefaults(
+      baseUrl = "https://fedramp.example.com",
+      locationId = "FEDRAMP-001",
+    )
+    assertThat(config.requireDataRightsAuthorization).isFalse()
+  }
+
+  // -- 19. Default config has requireDataRightsAuthorization=false --
+
+  @Test
+  fun `default KioskOpsConfig has requireDataRightsAuthorization false`() {
+    val config = KioskOpsConfig(
+      baseUrl = "https://default.example.com",
+      locationId = "DEFAULT-001",
+      kioskEnabled = true,
+    )
+    assertThat(config.requireDataRightsAuthorization).isFalse()
+  }
+
+  // -- 20. Authorizer can be changed dynamically between operations --
+
+  @Test
+  fun `authorizer can be changed dynamically between operations`() = runBlocking {
+    val manager = buildManager()
+
+    // First authorizer denies everything
+    manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
+    val denied = manager.deleteUserData("user-20")
+    assertThat(denied).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+
+    // Swap to an authorizer that allows everything
+    manager.setAuthorizer(DataRightsAuthorizer { _, _ -> true })
+    val allowed = manager.deleteUserData("user-20")
+    assertThat(allowed).isInstanceOf(DataDeletionResult.Success::class.java)
+  }
+
+  // -- Additional coverage: selective authorizer allows some operations but not others --
+
+  @Test
+  fun `authorizer can selectively allow export but deny delete`() = runBlocking {
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { op, _ ->
+      op == DataRightsOperation.EXPORT
+    })
+
+    val exportResult = manager.exportUserData("user-selective")
+    assertThat(exportResult).isNotInstanceOf(DataExportResult.Unauthorized::class.java)
+
+    val deleteResult = manager.deleteUserData("user-selective")
+    assertThat(deleteResult).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+  }
+
+  @Test
+  fun `authorizer can selectively allow by userId`() = runBlocking {
+    val manager = buildManager()
+    manager.setAuthorizer(DataRightsAuthorizer { _, uid ->
+      uid == "allowed-user"
+    })
+
+    val allowedResult = manager.deleteUserData("allowed-user")
+    assertThat(allowedResult).isInstanceOf(DataDeletionResult.Success::class.java)
+
+    val deniedResult = manager.deleteUserData("other-user")
+    assertThat(deniedResult).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+  }
+
+  @Test
+  fun `setAuthorizer null then requireAuthorization true blocks operations`() = runBlocking {
+    val manager = buildManager(requireAuthorization = true)
+
+    // Set an authorizer that allows
+    manager.setAuthorizer(DataRightsAuthorizer { _, _ -> true })
+    val allowed = manager.deleteUserData("user-null-req")
+    assertThat(allowed).isInstanceOf(DataDeletionResult.Success::class.java)
+
+    // Remove authorizer -- should block since requireAuthorization=true
+    manager.setAuthorizer(null)
+    val blocked = manager.deleteUserData("user-null-req")
+    assertThat(blocked).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
+  }
+}

--- a/sample-app/src/main/java/com/sarastarquant/kioskops/sample/DataRightsActivity.kt
+++ b/sample-app/src/main/java/com/sarastarquant/kioskops/sample/DataRightsActivity.kt
@@ -102,6 +102,7 @@ class DataRightsActivity : Activity() {
           }
           is DataExportResult.NoData -> "No data found for user '$userId'."
           is DataExportResult.Failed -> "Export failed: ${export.reason}"
+          is DataExportResult.Unauthorized -> "Export unauthorized. Configure a DataRightsAuthorizer."
         }
       }
     }
@@ -122,6 +123,7 @@ class DataRightsActivity : Activity() {
             appendLine("Audit events deleted: ${deletion.auditEventsDeleted}")
           }
           is DataDeletionResult.Failed -> "Deletion failed: ${deletion.reason}"
+          is DataDeletionResult.Unauthorized -> "Deletion unauthorized. Configure a DataRightsAuthorizer."
         }
       }
     }
@@ -136,6 +138,7 @@ class DataRightsActivity : Activity() {
             resultText.text = when (wipe) {
               is DataDeletionResult.Success -> "All SDK data wiped successfully."
               is DataDeletionResult.Failed -> "Wipe failed: ${wipe.reason}"
+              is DataDeletionResult.Unauthorized -> "Wipe unauthorized. Configure a DataRightsAuthorizer."
             }
           }
         }


### PR DESCRIPTION
## Summary

- DataRightsAuthorizer callback: host app verifies caller identity before export/delete/wipe operations
- CUI and CJIS presets require authorization by default; without an authorizer, operations return Unauthorized
- Unauthorized and Blocked results added to DataDeletionResult and DataExportResult
- All authorization decisions are audit-logged
- Migration guide for v0.9.x to v1.0.0
- 30 authorization tests; 1033 total tests, 76.8% coverage
- API dump updated (this becomes the frozen 1.0.0 contract)
