### PR TITLE
Fix stale JitPack version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.pzverkov:KioskOps-SDK-Android-Enterprise:v0.7.0")
+    implementation("com.github.pzverkov:KioskOps-SDK-Android-Enterprise:v0.9.0")
 }
 ```
 


### PR DESCRIPTION
Update JitPack install example from v0.7.0 to v0.9.0