### PR TITLE
Fix Maven Central publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,15 +81,15 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
-          ./gradlew :kiosk-ops-sdk:publishReleasePublicationToMavenCentralRepository -PVERSION_NAME="$VERSION" || {
+          ./gradlew :kiosk-ops-sdk:publishAndReleaseToMavenCentral -PVERSION_NAME="$VERSION" || {
             echo "::warning::Maven Central publish failed. Continuing."
           }
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
 
       - name: Publish to GitHub Packages
         run: |
@@ -100,8 +100,8 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
 
       - name: Generate release notes
         run: |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ dokka = "2.0.0"
 detekt = "1.23.7"
 kover = "0.9.1"
 cyclonedx = "3.2.3"
+mavenPublish = "0.30.0"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
@@ -72,3 +73,4 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 cyclonedx = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/kiosk-ops-sdk/build.gradle.kts
+++ b/kiosk-ops-sdk/build.gradle.kts
@@ -7,8 +7,7 @@ plugins {
   alias(libs.plugins.detekt)
   alias(libs.plugins.kover)
   alias(libs.plugins.cyclonedx)
-  `maven-publish`
-  signing
+  alias(libs.plugins.maven.publish)
 }
 
 kotlin {
@@ -158,54 +157,48 @@ val javadocJar by tasks.registering(Jar::class) {
   from(layout.buildDirectory.dir("dokka/html"))
 }
 
-// Publishing configuration for Maven Central, GitHub Packages, and JitPack
-android.publishing {
-  singleVariant("release") {
-    withSourcesJar()
-  }
-}
+// Maven Central publishing via Vanniktech plugin (handles Central Portal bundle upload)
+mavenPublishing {
+  publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
+  signAllPublications()
 
-afterEvaluate {
-  publishing {
-    publications {
-      create<MavenPublication>("release") {
-        from(components["release"])
+  coordinates(
+    groupId = "com.sarastarquant.kioskops",
+    artifactId = "kiosk-ops-sdk",
+    version = findProperty("VERSION_NAME")?.toString() ?: "0.1.0-SNAPSHOT",
+  )
 
-        groupId = "com.sarastarquant.kioskops"
-        artifactId = "kiosk-ops-sdk"
-        version = findProperty("VERSION_NAME")?.toString() ?: "0.1.0-SNAPSHOT"
+  pom {
+    name.set("KioskOps SDK")
+    description.set("Enterprise-grade Android SDK for offline-first operational events, local diagnostics, and fleet-friendly observability")
+    url.set("https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise")
 
-        artifact(javadocJar)
-
-        pom {
-          name.set("KioskOps SDK")
-          description.set("Enterprise-grade Android SDK for offline-first operational events, local diagnostics, and fleet-friendly observability")
-          url.set("https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise")
-
-          licenses {
-            license {
-              name.set("Business Source License 1.1")
-              url.set("https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/blob/main/LICENSE")
-            }
-          }
-
-          developers {
-            developer {
-              id.set("pzverkov")
-              name.set("Petro Zverkov")
-              organization.set("Sara Star Quant LLC")
-            }
-          }
-
-          scm {
-            url.set("https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise")
-            connection.set("scm:git:git://github.com/pzverkov/KioskOps-SDK-Android-Enterprise.git")
-            developerConnection.set("scm:git:ssh://github.com/pzverkov/KioskOps-SDK-Android-Enterprise.git")
-          }
-        }
+    licenses {
+      license {
+        name.set("Business Source License 1.1")
+        url.set("https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/blob/main/LICENSE")
       }
     }
 
+    developers {
+      developer {
+        id.set("pzverkov")
+        name.set("Petro Zverkov")
+        organization.set("Sara Star Quant LLC")
+      }
+    }
+
+    scm {
+      url.set("https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise")
+      connection.set("scm:git:git://github.com/pzverkov/KioskOps-SDK-Android-Enterprise.git")
+      developerConnection.set("scm:git:ssh://github.com/pzverkov/KioskOps-SDK-Android-Enterprise.git")
+    }
+  }
+}
+
+// GitHub Packages repository (secondary distribution)
+afterEvaluate {
+  publishing {
     repositories {
       maven {
         name = "GitHubPackages"
@@ -215,23 +208,6 @@ afterEvaluate {
           password = System.getenv("GITHUB_TOKEN") ?: findProperty("gpr.token")?.toString()
         }
       }
-      maven {
-        name = "MavenCentral"
-        url = uri("https://central.sonatype.com/api/v1/publisher/deployments/download/")
-        credentials {
-          username = System.getenv("MAVEN_CENTRAL_USERNAME") ?: findProperty("mavenCentral.username")?.toString()
-          password = System.getenv("MAVEN_CENTRAL_PASSWORD") ?: findProperty("mavenCentral.password")?.toString()
-        }
-      }
-    }
-  }
-
-  signing {
-    val signingKey = System.getenv("GPG_SIGNING_KEY")
-    val signingPassword = System.getenv("GPG_SIGNING_PASSWORD")
-    if (signingKey != null && signingPassword != null) {
-      useInMemoryPgpKeys(signingKey, signingPassword)
-      sign(publishing.publications["release"])
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace manual maven-publish + signing plugins with com.vanniktech.maven.publish
- Sonatype Central Portal requires bundle upload API, not standard Maven PUT
- Vanniktech plugin handles Central Portal protocol, signing, sources JAR, and javadoc JAR
- Release workflow updated to use publishAndReleaseToMavenCentral task
- Credentials passed via ORG_GRADLE_PROJECT_ env vars (Vanniktech convention)
