### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -126,6 +126,12 @@ KioskOps SDK includes enterprise security features:
 - Build attestation with artifact SHA-256 hash in CI job summary for supply chain verification
 - Detekt SARIF findings uploaded to GitHub Security tab for proactive static analysis review
 
+### Data Rights Authorization (v1.0.0)
+- `DataRightsAuthorizer` callback prevents unauthorized data export, deletion, and wipe on shared kiosk devices
+- CUI and CJIS presets require authorization by default
+- All authorization decisions audit-logged for compliance visibility
+- API surface frozen under semantic versioning
+
 ### Disclaimer
 
 References to regulatory frameworks (NIST 800-53, FedRAMP, GDPR, ISO 27001,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-04
+
+Stable release: API freeze, data rights authorization, semantic versioning commitment.
+
+### Added
+
+- `DataRightsAuthorizer` callback for host-app identity verification before export/delete/wipe operations
+- `DataRightsOperation` enum: EXPORT, DELETE, WIPE
+- `DataDeletionResult.Unauthorized` and `DataExportResult.Unauthorized` result types
+- `KioskOpsConfig.requireDataRightsAuthorization` flag (enabled by default in CUI and CJIS presets)
+- `KioskOpsSdk.setDataRightsAuthorizer()` for registering the authorization callback
+- Migration guide for v0.9.x to v1.0.0
+
+### Changed
+
+- CUI and CJIS presets now require `DataRightsAuthorizer`; without one, data rights operations return `Unauthorized`
+- API surface frozen; breaking changes only in major versions per semantic versioning
+
+### Security
+
+- Shared kiosk devices: prevents one user from accessing or erasing another user's local data
+- All authorization decisions (allowed, denied, blocked) are audit-logged
+
 ## [0.9.0] - 2026-04-04
 
 Lifecycle-aware telemetry, reactive config updates, global PII patterns, anomaly baseline seeding, instrumented tests, and Maven Central publication.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:0.9.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.0.0")
 }
 ```
 
@@ -56,7 +56,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:0.9.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.0.0")
 }
 ```
 
@@ -72,7 +72,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.pzverkov:KioskOps-SDK-Android-Enterprise:v0.9.0")
+    implementation("com.github.pzverkov:KioskOps-SDK-Android-Enterprise:v1.0.0")
 }
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -278,9 +278,9 @@ Focus: Lifecycle-aware telemetry, reactive config updates, global PII coverage, 
 Focus: Production stability, distribution, LTS commitment, and cross-platform support.
 
 ### Stability
-- [ ] API freeze and semantic versioning commitment
+- [x] API freeze and semantic versioning commitment
 - [ ] Long-term support (LTS) branch
-- [ ] Migration guides for all breaking changes
+- [x] Migration guides for all breaking changes
 
 ### Distribution
 - [x] Maven Central publication with PGP-signed artifacts (completed in v0.9.0)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -105,6 +105,15 @@
 | Instrumented tests | CI | Real AndroidKeyStore, on-device SQLite, WorkManager on real scheduler |
 | Build attestation | CI | CI summary with test count, coverage, AAR SHA-256, SBOM hash, toolchain versions |
 
+### Data Rights Authorization (v1.0.0)
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| Data rights authorizer | Off | Host-app callback to verify caller identity before export/delete/wipe |
+| CUI/CJIS enforcement | On (in presets) | CUI and CJIS presets require authorizer; operations return Unauthorized without one |
+| Authorization audit | On | All authorization decisions logged to persistent audit trail |
+| API freeze | Stable | Semantic versioning commitment; breaking changes only in major versions |
+
 See [Security & Compliance](SECURITY_COMPLIANCE.md) for the full threat model.
 
 ## Fleet Operations

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.3
 info:
   title: KioskOps Events Ingest API
-  version: 0.1.0
+  version: 1.0.0
   description: |
-    Minimal ingest endpoint for the KioskOps SDK.
+    Batch ingest endpoint for the KioskOps SDK.
 
     Key properties:
       - Idempotency per event: (id, idempotencyKey)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ kotlin.code.style=official
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 # SDK Version
-VERSION_NAME=0.9.0
+VERSION_NAME=1.0.0

--- a/sample-app/src/main/java/com/sarastarquant/kioskops/sample/SampleApp.kt
+++ b/sample-app/src/main/java/com/sarastarquant/kioskops/sample/SampleApp.kt
@@ -42,6 +42,14 @@ class SampleApp : Application() {
       Log.w("KioskOps", "SDK error: ${error.message}", error.cause)
     })
 
+    // v1.0.0: Data rights authorization callback.
+    // cuiDefaults requires authorization before export/delete/wipe operations.
+    // In production, verify the caller's identity (PIN, biometric, backend token).
+    sdk.setDataRightsAuthorizer { operation, userId ->
+      Log.i("KioskOps", "Data rights authorization requested: $operation for user=$userId")
+      true // Sample app always allows; production must verify identity
+    }
+
     // Register event schemas for validation.
     // cuiDefaults enables strict validation; unregistered event types are rejected.
     sdk.schemaRegistry.register("SCAN", """


### PR DESCRIPTION
## Summary

- Bump VERSION_NAME to 1.0.0
- Update README installation versions (Maven Central, GitHub Packages, JitPack)
- Add CHANGELOG v1.0.0 section (DataRightsAuthorizer, API freeze)
- Check off completed v1.0.0 items in ROADMAP
- Add v1.0.0 feature table in FEATURES.md and security section in SECURITY.md
- Sample app: register DataRightsAuthorizer (required by cuiDefaults)
- Update openapi.yaml version to 1.0.0
- Repo description and 20 topics updated for discoverability
