### PR TITLE
Align gradle minSdk and sample-app version with v1.1.0

### DIFF
--- a/kiosk-ops-sdk/build.gradle.kts
+++ b/kiosk-ops-sdk/build.gradle.kts
@@ -19,7 +19,7 @@ android {
   compileSdk = 36
 
   defaultConfig {
-    minSdk = 31
+    minSdk = 33
     consumerProguardFiles("consumer-rules.pro")
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     buildConfigField("String", "SDK_VERSION", "\"${findProperty("VERSION_NAME") ?: "0.0.0-SNAPSHOT"}\"")

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -13,10 +13,10 @@ android {
 
   defaultConfig {
     applicationId = "com.sarastarquant.kioskops.sample"
-    minSdk = 31
+    minSdk = 33
     targetSdk = 36
-    versionCode = 1
-    versionName = "0.1.0"
+    versionCode = 2
+    versionName = "1.1.0"
   }
 
   buildTypes {


### PR DESCRIPTION
## Summary

v1.1.0 simplified `SDK_INT` gates and documented minSdk 33 but the two Gradle files still declared `minSdk = 31`. As shipped, the AAR remains installable on Android 12 and the merged AndroidManifest emits `minSdkVersion=31`, which contradicts the release. Sample-app `versionName` was also still `0.1.0` while the SDK it exercises is `1.1.0`; reviewers read that as drift between the reference integration and the library.

## Changes

- `kiosk-ops-sdk/build.gradle.kts`: `minSdk` 31 -> 33
- `sample-app/build.gradle.kts`: `minSdk` 31 -> 33, `versionName` 0.1.0 -> 1.1.0, `versionCode` 1 -> 2

## Verification

- `./gradlew :kiosk-ops-sdk:assembleRelease` green; released AAR manifest now carries `android:minSdkVersion="33"`.
- `./gradlew :sample-app:assembleDebug` green against the new SDK.
