### PR TITLE
Bump CI instrumented-tests emulator from API 31 to API 33

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,9 +199,9 @@ jobs:
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
             "emulator" \
-            "system-images;android-31;default;x86_64" \
+            "system-images;android-33;default;x86_64" \
             "platform-tools" \
-            "platforms;android-31"
+            "platforms;android-33"
 
       - name: Create and start emulator
         run: |
@@ -211,7 +211,7 @@ jobs:
 
           echo "no" | "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" create avd \
             --name "test_avd" \
-            --package "system-images;android-31;default;x86_64" \
+            --package "system-images;android-33;default;x86_64" \
             --device "pixel_6" \
             --force
 


### PR DESCRIPTION
## Summary

The `instrumented-tests` job on main failed after v1.1.0 merged because the emulator is pinned to API 31 while the SDK's new `minSdk` is 33. AGP then refuses to run tests on the device:

```
Skipping device 'emulator-5554 - 12' for ':kiosk-ops-sdk:': minSdkVersion [33] > deviceApiLevel [31]
No compatible devices connected.
```

Reference: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/actions/runs/24614517607/job/71974425727

## Change

- `.github/workflows/build.yml`: emulator `system-images` and `platforms` pinned to `android-33` (was `android-31`) in the three `sdkmanager` / `avdmanager` invocations.

## Verification

- Grep confirms no remaining `android-31` references in the workflow.
- Rerunning the `instrumented-tests` job after this lands will boot an API 33 emulator that satisfies the new `minSdk`.
