### PR TITLE
Clean stale Known Limitations entries in ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -345,7 +345,7 @@ toolchain surface, and prepare for cross-platform consumers.
 
 ### Stability
 - [ ] Long-term support (LTS) branch (cherry-pick security fixes to v1.1.x)
-- [ ] AGP 9.x evaluation — brings Bouncy Castle 1.84+ and closes the
+- [ ] AGP 9.x evaluation - brings Bouncy Castle 1.84+ and closes the
   remaining build-classpath CVE exposure
 
 ### Distribution

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -163,11 +163,10 @@ See [Server API Contract](openapi.yaml) for the ingest endpoint specification.
 
 ## Known Limitations
 
-- ~~**Audit chain is process-local**: Restarts from GENESIS on app initialization~~ **Fixed in v0.2.0**
 - **Lock-task mode**: Best-effort detection; not a full kiosk controller
 - **Request signing**: Client-side only; server verification is your responsibility
 - **Room migrations**: Provided for Queue v2->v3->v4 and Audit v1->v2
-- **Key attestation**: Always available (minSdk 31 since v0.9.0)
+- **Key attestation**: Always available (minSdk 33 since v1.1.0)
 - **StrongBox**: Hardware support varies by device
 - **PII detection** (v0.5.0): Regex-based; expanded in v0.9.0 with 8 country-specific patterns and safe exclusions; may still produce false positives for uncommon formats
 - **Anomaly detection** (v0.5.0): Requires baseline period; baseline seeding (v0.9.0) addresses cold-start via `seedBaseline()` API


### PR DESCRIPTION
## Summary

Two stale items cleaned up in `docs/FEATURES.md`, plus one non-ASCII character in `ROADMAP.md`.

## Changes

- `docs/FEATURES.md` Known Limitations:
  - Removed the v0.2.0 strikethrough note about the process-local audit chain. It was useful context at v0.3.0; five releases later it's noise.
  - Corrected `Key attestation: Always available (minSdk 31 since v0.9.0)` to `minSdk 33 since v1.1.0`. The v1.1.0 rewrite missed this line; the v0.9.0 reference no longer matches the baseline.

## Verification

- `grep` confirms no remaining `minSdk 31` references outside historical CHANGELOG / MIGRATION / ROADMAP entries.
