### PR TITLE
P0 reliability hardening: corruption handler wiring, SENDING recovery, batch-transient fix

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -11,17 +11,17 @@ It defaults to a **security/compliance-maximalist posture**:
 
 ## 1) Add the dependency
 
-Today this repo is a source-based integration:
+The SDK is published to Maven Central. Add it to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-  implementation(project(":kiosk-ops-sdk"))
+  implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:<latest>")
 }
 ```
 
-When publishing, recommended Maven coordinates:
-- groupId: `com.sarastarquant.kioskops`
-- artifact: `kioskops-sdk`
+See the [README Installation](../README.md#installation) section for the current
+release version, GitHub Packages coordinates, and the JitPack fallback. In-repo
+consumers (sample-app) continue to use `implementation(project(":kiosk-ops-sdk"))`.
 
 ---
 

--- a/kiosk-ops-sdk/api/kiosk-ops-sdk.api
+++ b/kiosk-ops-sdk/api/kiosk-ops-sdk.api
@@ -3832,9 +3832,11 @@ public abstract interface class com/sarastarquant/kioskops/sdk/queue/QueueDao {
 	public abstract fun insert (Lcom/sarastarquant/kioskops/sdk/queue/QueueEventEntity;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun loadNextBatch (JILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun loadQuarantinedSummaries (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun markBatchFailureNoAttemptBump (Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun markFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun markSending (Ljava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun markSent (Ljava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun reconcileStaleSending (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun sumNotSentBytes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -3853,9 +3855,11 @@ public final class com/sarastarquant/kioskops/sdk/queue/QueueDao_Impl : com/sara
 	public fun insert (Lcom/sarastarquant/kioskops/sdk/queue/QueueEventEntity;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun loadNextBatch (JILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun loadQuarantinedSummaries (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun markBatchFailureNoAttemptBump (Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun markFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun markSending (Ljava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun markSent (Ljava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun reconcileStaleSending (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun sumNotSentBytes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -3939,6 +3943,7 @@ public final class com/sarastarquant/kioskops/sdk/queue/QueueRepository {
 	public static synthetic fun enqueue$default (Lcom/sarastarquant/kioskops/sdk/queue/QueueRepository;Ljava/lang/String;Ljava/lang/String;Lcom/sarastarquant/kioskops/sdk/KioskOpsConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getAnomalous (FLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getByUserId (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun markBatchFailureNoAttemptBump (Ljava/lang/String;Ljava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun markFailed (Ljava/lang/String;Ljava/lang/String;JILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun markFailed$default (Lcom/sarastarquant/kioskops/sdk/queue/QueueRepository;Ljava/lang/String;Ljava/lang/String;JILjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun markSending (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3947,6 +3952,7 @@ public final class com/sarastarquant/kioskops/sdk/queue/QueueRepository {
 	public static synthetic fun nextBatch$default (Lcom/sarastarquant/kioskops/sdk/queue/QueueRepository;JILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun quarantinedSummaries (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun quarantinedSummaries$default (Lcom/sarastarquant/kioskops/sdk/queue/QueueRepository;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun reconcileStaleSending (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/sarastarquant/kioskops/sdk/queue/QueueStates {

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
@@ -119,13 +119,31 @@ class KioskOpsSdk private constructor(
     delegate = AesGcmKeystoreCryptoProvider(alias = "kioskops_exports_aesgcm_v1")
   )
 
-  // v0.8.0 Database encryption (SQLCipher)
-  private val dbOpenHelperFactory: androidx.sqlite.db.SupportSQLiteOpenHelper.Factory? =
-    if (cfg().databaseEncryptionPolicy.enabled) {
-      com.sarastarquant.kioskops.sdk.crypto.DatabaseEncryptionProvider.createFactory(appContext)
-    } else {
-      null
-    }
+  // v0.8.0 Database encryption (SQLCipher) with v1.2.0 corruption handling.
+  // Wraps the delegate factory (SQLCipher when db encryption is on, framework default otherwise)
+  // so corruption surfaces to the host via KioskOpsErrorListener and lands in the audit trail
+  // before Room's default delete-and-recreate runs.
+  private val dbOpenHelperFactory: androidx.sqlite.db.SupportSQLiteOpenHelper.Factory =
+    com.sarastarquant.kioskops.sdk.queue.CorruptionHandlingOpenHelperFactory(
+      delegate = if (cfg().databaseEncryptionPolicy.enabled) {
+        com.sarastarquant.kioskops.sdk.crypto.DatabaseEncryptionProvider.createFactory(appContext)
+      } else {
+        androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory()
+      },
+      onCorruption = { db ->
+        val path = try { db.path } catch (_: Throwable) { null }
+        logs.e("SDK", "Database corruption detected at ${path ?: "unknown"}")
+        notifyError(
+          KioskOpsError.StorageError(
+            message = "Database corruption detected at ${path ?: "unknown"}; database will be recreated",
+          )
+        )
+        audit.record(
+          "database_corruption_detected",
+          mapOf("path" to (path ?: "unknown")),
+        )
+      },
+    )
 
   init {
     // Set audit database encryption before any getInstance() calls
@@ -1154,6 +1172,11 @@ class KioskOpsSdk private constructor(
   companion object {
     @JvmStatic val SDK_VERSION: String = BuildConfig.SDK_VERSION
 
+    // Rows older than this in SENDING on init are assumed crash-abandoned. Five minutes is
+    // well past OkHttp's default call timeout and typical worker budget, so genuinely in-flight
+    // requests in a concurrent process won't be reset mid-send.
+    private const val STALE_SENDING_WINDOW_MS = 5L * 60L * 1000L
+
     @Volatile private var INSTANCE: KioskOpsSdk? = null
 
     @JvmStatic
@@ -1184,6 +1207,12 @@ class KioskOpsSdk private constructor(
       created.logs.i("SDK", "Initialized")
       created.audit.record("sdk_initialized")
       created.telemetry.emit("sdk_initialized", mapOf("sdkVersion" to SDK_VERSION))
+      // Rescue SENDING rows stranded by a prior process crash. Gate on an age > STALE_SENDING_WINDOW_MS
+      // so any in-flight rows from a concurrent process (rare but possible) are left alone.
+      created.javaInteropScope.launch {
+        val staleBefore = created.clock.nowMs() - STALE_SENDING_WINDOW_MS
+        created.queue.reconcileStaleSending(staleBefore)
+      }
       created.applySchedulingFromConfig()
       com.sarastarquant.kioskops.sdk.lifecycle.SdkLifecycleObserver.register(
         sdkProvider = { INSTANCE },

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/CorruptionHandlingOpenHelperFactory.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/CorruptionHandlingOpenHelperFactory.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.queue
+
+import androidx.annotation.RestrictTo
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+
+/**
+ * Wraps a [SupportSQLiteOpenHelper.Factory] so the Room/SQLCipher-managed callback's
+ * `onCorruption` hook fires an application-level callback before Room's default
+ * recreate-the-database behavior runs. Used to surface
+ * [com.sarastarquant.kioskops.sdk.KioskOpsError.StorageError] to the host app
+ * and append an audit entry when a Room-managed database file is corrupt.
+ *
+ * The delegate factory's own corruption handling (delete + recreate) still runs
+ * after the callback, so the SDK recovers instead of repeatedly crashing.
+ *
+ * @since 1.2.0
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+internal class CorruptionHandlingOpenHelperFactory(
+  private val delegate: SupportSQLiteOpenHelper.Factory,
+  private val onCorruption: (SupportSQLiteDatabase) -> Unit,
+) : SupportSQLiteOpenHelper.Factory {
+
+  override fun create(
+    configuration: SupportSQLiteOpenHelper.Configuration,
+  ): SupportSQLiteOpenHelper {
+    val originalCallback = configuration.callback
+    val wrapped = object : SupportSQLiteOpenHelper.Callback(originalCallback.version) {
+      override fun onConfigure(db: SupportSQLiteDatabase) = originalCallback.onConfigure(db)
+      override fun onCreate(db: SupportSQLiteDatabase) = originalCallback.onCreate(db)
+      override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) =
+        originalCallback.onUpgrade(db, oldVersion, newVersion)
+      override fun onDowngrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) =
+        originalCallback.onDowngrade(db, oldVersion, newVersion)
+      override fun onOpen(db: SupportSQLiteDatabase) = originalCallback.onOpen(db)
+
+      override fun onCorruption(db: SupportSQLiteDatabase) {
+        try {
+          onCorruption.invoke(db)
+        } catch (_: Throwable) {
+          // Callback must not block recovery.
+        }
+        originalCallback.onCorruption(db)
+      }
+    }
+
+    val newConfig = SupportSQLiteOpenHelper.Configuration.builder(configuration.context)
+      .name(configuration.name)
+      .callback(wrapped)
+      .build()
+    return delegate.create(newConfig)
+  }
+}

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/QueueDao.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/QueueDao.kt
@@ -32,6 +32,24 @@ interface QueueDao {
   @Query("UPDATE queue_events SET state = 'SENT', lastError = NULL, updatedAtEpochMs = :nowMs WHERE id = :id")
   suspend fun markSent(id: String, nowMs: Long)
 
+  /**
+   * Rescue SENDING rows stranded across a process restart. An event is marked SENDING just
+   * before transport; if the process dies mid-flight, the row stays SENDING forever and
+   * loadNextBatch never picks it up (it only selects PENDING/FAILED), so the event silently
+   * rots until retention deletes it.
+   *
+   * [staleBeforeEpochMs] is an age gate so a concurrently-running process's genuinely in-flight
+   * rows aren't reset mid-send. Callers pass e.g. now - 2 x callTimeout.
+   *
+   * Returns the number of rows reset.
+   * @since 1.2.0
+   */
+  @Query(
+    "UPDATE queue_events SET state = 'PENDING', updatedAtEpochMs = :nowMs " +
+      "WHERE state = 'SENDING' AND updatedAtEpochMs < :staleBeforeEpochMs"
+  )
+  suspend fun reconcileStaleSending(staleBeforeEpochMs: Long, nowMs: Long): Int
+
   @Query(
     "UPDATE queue_events SET " +
       "state = CASE WHEN :permanentFailure = 1 THEN 'QUARANTINED' ELSE 'FAILED' END, " +
@@ -50,6 +68,32 @@ interface QueueDao {
     nextAttemptAtMs: Long,
     permanentFailure: Int,
     nowMs: Long
+  )
+
+  /**
+   * Record a batch-level failure without bumping per-event attempts. Used when the whole
+   * batch fails for reasons outside the individual event (network transient, auth error,
+   * schema-level permanent). Without this, a single 30-minute outage processed as 50-event
+   * batches would march every event to `maxAttemptsPerEvent` and quarantine the fleet's
+   * backlog despite nothing being wrong with the events.
+   *
+   * Still sets state=FAILED and records the error + next-attempt gate so the event is
+   * eligible again after backoff.
+   * @since 1.2.0
+   */
+  @Query(
+    "UPDATE queue_events SET " +
+      "state = 'FAILED', " +
+      "lastError = :error, " +
+      "nextAttemptAtEpochMs = :nextAttemptAtMs, " +
+      "updatedAtEpochMs = :nowMs " +
+      "WHERE id = :id"
+  )
+  suspend fun markBatchFailureNoAttemptBump(
+    id: String,
+    error: String,
+    nextAttemptAtMs: Long,
+    nowMs: Long,
   )
 
   @Query("DELETE FROM queue_events WHERE id = :id")

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/QueueRepository.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/QueueRepository.kt
@@ -188,8 +188,29 @@ class QueueRepository(
 
   suspend fun markSending(id: String) = dao.markSending(id, System.currentTimeMillis())
 
+  /**
+   * Reset SENDING rows older than [staleBeforeEpochMs] back to PENDING. Called on SDK init
+   * so crash-abandoned events don't rot forever. Returns number of rows rescued.
+   * @since 1.2.0
+   */
+  suspend fun reconcileStaleSending(staleBeforeEpochMs: Long): Int {
+    val reset = dao.reconcileStaleSending(staleBeforeEpochMs, System.currentTimeMillis())
+    if (reset > 0) {
+      logs.w("Queue", "Reset $reset stale SENDING rows to PENDING on init")
+    }
+    return reset
+  }
+
   suspend fun markFailed(id: String, err: String, nextAttemptAtMs: Long, permanentFailure: Int, quarantineReason: String? = null) =
     dao.markFailed(id, err, quarantineReason, nextAttemptAtMs, permanentFailure, System.currentTimeMillis())
+
+  /**
+   * Record a batch-level failure for an event without incrementing its attempts counter.
+   * See [QueueDao.markBatchFailureNoAttemptBump].
+   * @since 1.2.0
+   */
+  suspend fun markBatchFailureNoAttemptBump(id: String, err: String, nextAttemptAtMs: Long) =
+    dao.markBatchFailureNoAttemptBump(id, err, nextAttemptAtMs, System.currentTimeMillis())
 
   suspend fun markSent(id: String) = dao.markSent(id, System.currentTimeMillis())
 

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/sync/SyncEngine.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/sync/SyncEngine.kt
@@ -166,11 +166,14 @@ class SyncEngine(
       }
 
       is TransportResult.TransientFailure -> {
+        // Batch-level transient failure is not the event's fault; do not bump per-event
+        // attempts. A long outage would otherwise march every event to maxAttemptsPerEvent
+        // and quarantine the backlog for no good reason.
         var nextBackoffMs = 0L
         for (e in batch) {
           val delay = Backoff.nextDelayMs(e.attempts)
           nextBackoffMs = maxOf(nextBackoffMs, delay)
-          queue.markFailed(e.id, res.message, nextAttemptAtMs = now + delay, permanentFailure = 0)
+          queue.markBatchFailureNoAttemptBump(e.id, res.message, nextAttemptAtMs = now + delay)
         }
 
         audit.record("sync_batch_transient_failure", mapOf("httpStatus" to (res.httpStatus?.toString() ?: "")))
@@ -189,11 +192,12 @@ class SyncEngine(
       }
 
       is TransportResult.PermanentFailure -> {
-        // Auth/config/schema errors. Do not auto-perma-fail queued events here;
-        // the operator may fix config and retry.
+        // Auth/config/schema errors: batch-level, not per-event. Do not auto-perma-fail or
+        // bump attempts; the operator may fix config and retry. Consistent with
+        // TransientFailure above.
         for (e in batch) {
           val delay = Backoff.nextDelayMs(e.attempts)
-          queue.markFailed(e.id, res.message, nextAttemptAtMs = now + delay, permanentFailure = 0)
+          queue.markBatchFailureNoAttemptBump(e.id, res.message, nextAttemptAtMs = now + delay)
         }
 
         audit.record("sync_batch_permanent_failure", mapOf("httpStatus" to (res.httpStatus?.toString() ?: "")))

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/queue/CorruptionHandlingOpenHelperFactoryTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/queue/CorruptionHandlingOpenHelperFactoryTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.queue
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CorruptionHandlingOpenHelperFactoryTest {
+
+  private fun stubDb(): SupportSQLiteDatabase = java.lang.reflect.Proxy.newProxyInstance(
+    SupportSQLiteDatabase::class.java.classLoader,
+    arrayOf(SupportSQLiteDatabase::class.java),
+  ) { _, _, _ -> null } as SupportSQLiteDatabase
+
+  private class FakeOpenHelper : SupportSQLiteOpenHelper {
+    override val databaseName: String? = null
+    override fun close() = Unit
+    override val readableDatabase: SupportSQLiteDatabase
+      get() = error("not used")
+    override val writableDatabase: SupportSQLiteDatabase
+      get() = error("not used")
+    override fun setWriteAheadLoggingEnabled(enabled: Boolean) = Unit
+  }
+
+  private class CapturingDelegate : SupportSQLiteOpenHelper.Factory {
+    var captured: SupportSQLiteOpenHelper.Callback? = null
+    override fun create(configuration: SupportSQLiteOpenHelper.Configuration): SupportSQLiteOpenHelper {
+      captured = configuration.callback
+      return FakeOpenHelper()
+    }
+  }
+
+  private class RecordingCallback : SupportSQLiteOpenHelper.Callback(1) {
+    var corruptionCalls = 0
+    override fun onCreate(db: SupportSQLiteDatabase) = Unit
+    override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+    override fun onCorruption(db: SupportSQLiteDatabase) { corruptionCalls++ }
+  }
+
+  @Test
+  fun `wrapping callback invokes corruption hook before delegate callback`() {
+    val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+    val original = RecordingCallback()
+    val capture = CapturingDelegate()
+
+    var hookCalled = 0
+    val factory = CorruptionHandlingOpenHelperFactory(
+      delegate = capture,
+      onCorruption = { hookCalled++ },
+    )
+
+    factory.create(
+      SupportSQLiteOpenHelper.Configuration.builder(ctx)
+        .name("x.db")
+        .callback(original)
+        .build()
+    )
+
+    capture.captured!!.onCorruption(stubDb())
+
+    assertThat(hookCalled).isEqualTo(1)
+    assertThat(original.corruptionCalls).isEqualTo(1)
+  }
+
+  @Test
+  fun `hook exceptions do not prevent delegate corruption recovery`() {
+    val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+    val original = RecordingCallback()
+    val capture = CapturingDelegate()
+
+    val factory = CorruptionHandlingOpenHelperFactory(
+      delegate = capture,
+      onCorruption = { error("host app listener blew up") },
+    )
+
+    factory.create(
+      SupportSQLiteOpenHelper.Configuration.builder(ctx)
+        .name("y.db")
+        .callback(original)
+        .build()
+    )
+
+    capture.captured!!.onCorruption(stubDb())
+    assertThat(original.corruptionCalls).isEqualTo(1)
+  }
+}

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/queue/QueueDaoTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/queue/QueueDaoTest.kt
@@ -212,4 +212,53 @@ class QueueDaoTest {
     dao.insert(entity(id = "e1", idempotencyKey = "shared-key"))
     dao.insert(entity(id = "e2", idempotencyKey = "shared-key"))
   }
+
+  @Test
+  fun `reconcileStaleSending resets only old SENDING rows`() = runTest {
+    // Simulate crash: three events marked SENDING at different times.
+    dao.insert(entity(id = "old1", idempotencyKey = "k-old1"))
+    dao.insert(entity(id = "old2", idempotencyKey = "k-old2"))
+    dao.insert(entity(id = "fresh", idempotencyKey = "k-fresh"))
+    dao.markSending("old1", now - 10 * 60 * 1000) // 10 min old
+    dao.markSending("old2", now - 6 * 60 * 1000) // 6 min old
+    dao.markSending("fresh", now - 30 * 1000) // 30s old
+
+    val threshold = now - 5 * 60 * 1000 // 5 minute window
+    val reset = dao.reconcileStaleSending(staleBeforeEpochMs = threshold, nowMs = now)
+    assertThat(reset).isEqualTo(2)
+
+    // Only the fresh row stays SENDING (not eligible); the two old rows are now PENDING.
+    val eligible = dao.loadNextBatch(now + 1000, 10).map { it.id }.toSet()
+    assertThat(eligible).containsExactly("old1", "old2")
+  }
+
+  @Test
+  fun `reconcileStaleSending leaves PENDING and FAILED untouched`() = runTest {
+    dao.insert(entity(id = "p1", idempotencyKey = "kp1"))
+    dao.insert(entity(id = "f1", idempotencyKey = "kf1"))
+    dao.markFailed("f1", "x", null, now + 1000, 0, now - 10 * 60 * 1000)
+
+    val reset = dao.reconcileStaleSending(staleBeforeEpochMs = now, nowMs = now)
+    assertThat(reset).isEqualTo(0)
+  }
+
+  @Test
+  fun `markBatchFailureNoAttemptBump preserves attempts counter`() = runTest {
+    dao.insert(entity())
+    // Bump attempts once via a real per-event failure so we can observe the counter later.
+    dao.markFailed("evt-1", "per_event_err", null, now + 1000, 0, now + 100)
+
+    val afterFirst = dao.loadNextBatch(now + 2000, 10).first()
+    assertThat(afterFirst.attempts).isEqualTo(1)
+
+    // Batch transient: 5 times, attempts must stay at 1.
+    repeat(5) {
+      dao.markBatchFailureNoAttemptBump("evt-1", "network_5xx", now + 1000, now + 200)
+    }
+
+    val afterBatch = dao.loadNextBatch(now + 2000, 10).first()
+    assertThat(afterBatch.attempts).isEqualTo(1)
+    assertThat(afterBatch.lastError).isEqualTo("network_5xx")
+    assertThat(afterBatch.state).isEqualTo(QueueStates.FAILED)
+  }
 }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/sync/SyncEngineTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/sync/SyncEngineTest.kt
@@ -261,6 +261,59 @@ class SyncEngineTest {
   }
 
   @Test
+  fun `batch-level transient does not bump per-event attempts across many cycles`() = runTest {
+    // Regression for M1: a 30-minute outage processed as batches must not march every event
+    // to maxAttemptsPerEvent and silently quarantine the backlog.
+    server.dispatcher = object : Dispatcher() {
+      override fun dispatch(request: RecordedRequest): MockResponse =
+        MockResponse.Builder().code(500).body("oops").build()
+    }
+
+    val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    val logs = RingLog(context)
+    val json = Json { ignoreUnknownKeys = true; explicitNulls = false }
+
+    val cfg = KioskOpsConfig(
+      baseUrl = server.url("/").toString(),
+      locationId = "TEST",
+      kioskEnabled = false,
+      syncPolicy = SyncPolicy(enabled = true, endpointPath = "events/batch", batchSize = 10, maxAttemptsPerEvent = 3),
+      securityPolicy = SecurityPolicy.maximalistDefaults().copy(encryptQueuePayloads = false),
+      retentionPolicy = RetentionPolicy.maximalistDefaults(),
+      telemetryPolicy = TelemetryPolicy.maximalistDefaults()
+    )
+
+    val queue = QueueRepository(context, logs, NoopCryptoProvider)
+    val audit = PersistentAuditTrail(context, retentionProvider = { cfg.retentionPolicy }, clock = Clock.SYSTEM)
+    val transport = OkHttpTransport(OkHttpClient.Builder().build(), json, logs, authProvider = null)
+
+    repeat(5) { i -> assertThat(queue.enqueue("T", "{\"i\":$i}", cfg).isAccepted).isTrue() }
+
+    val clock = TestClock(now = 1_000L)
+    val engine = SyncEngine(
+      context = context,
+      cfgProvider = { cfg },
+      queue = queue,
+      transport = transport,
+      logs = logs,
+      telemetry = object : TelemetrySink { override fun emit(event: String, fields: Map<String, String>) {} },
+      audit = audit,
+      clock = clock
+    )
+
+    // 10 transient cycles with maxAttemptsPerEvent=3 would absolutely quarantine everything
+    // under the old behavior. New behavior: attempts stay at 0, nothing is quarantined.
+    repeat(10) {
+      val r = engine.flushOnce()
+      assertThat(r).isInstanceOf(TransportResult.TransientFailure::class.java)
+      clock.now += 60_000L // step past any backoff
+    }
+
+    assertThat(queue.countActive()).isEqualTo(5)
+    assertThat(queue.quarantinedSummaries(limit = 50)).isEmpty()
+  }
+
+  @Test
   fun `maxAttemptsPerEvent moves event to quarantine even if retryable`() = runTest {
     server.dispatcher = object : Dispatcher() {
       override fun dispatch(request: RecordedRequest): MockResponse {


### PR DESCRIPTION
## Summary

Four correctness fixes from the v1.2 improvement audit, shipped together because their tests and docs are intertwined. Each is scoped tightly; no surrounding refactors.

## Wire `DatabaseCorruptionHandler`

`DatabaseCorruptionHandler` was declared in v0.8.0 and referenced only by its own test; no code path installed it on the queue or audit databases, even though `FEATURES.md` advertised "Corruption recovery: On - `DatabaseCorruptionHandler` notifies error listener and recreates database."

This PR adds `CorruptionHandlingOpenHelperFactory`, a wrapping `SupportSQLiteOpenHelper.Factory` that intercepts `SupportSQLiteOpenHelper.Callback.onCorruption` and forwards it to a host-provided hook before Room's default delete-and-recreate recovery runs. `KioskOpsSdk` now always builds the factory (wrapping the SQLCipher factory when `databaseEncryptionPolicy.enabled`, the `FrameworkSQLiteOpenHelperFactory` otherwise) and threads `KioskOpsErrorListener.StorageError` plus an audit entry through the hook.

The original `DatabaseCorruptionHandler` class is untouched to keep this PR scope tight; it can be removed in a follow-up once no external references remain.

## Reset stranded `SENDING` rows on init

`SyncEngine` marks each event `SENDING` immediately before the HTTP call. A crash, OOM, force-stop, or reboot mid-send leaves the row `SENDING` forever; `QueueDao.loadNextBatch` only selects `PENDING`/`FAILED`, so the event silently rots until retention deletes it.

New `QueueDao.reconcileStaleSending(staleBeforeEpochMs, nowMs)` flips stale rows back to `PENDING`. `KioskOpsSdk.init` runs it with a 5-minute age gate so any genuinely in-flight row from a concurrent process is left alone; five minutes is well past OkHttp's default call timeout and typical worker budget.

## Don't bump per-event attempts on batch-level failures

`SyncEngine` called `markFailed` (which increments `attempts`) for every event in a batch when transport returned `TransientFailure` or `PermanentFailure`. A 30-minute outage processed as 50-event batches marched every event to `SyncPolicy.maxAttemptsPerEvent` and quarantined the backlog, even though the environment was the problem and not the events.

New `QueueDao.markBatchFailureNoAttemptBump` updates `state=FAILED`, `lastError`, and `nextAttemptAtEpochMs` without incrementing `attempts`. `SyncEngine` uses it on both the `TransientFailure` and `PermanentFailure` branches; per-event paths (`missing_ack`, per-event `accepted=false`) continue to use `markFailed` because those are genuinely the event's responsibility.

## Fix `docs/INTEGRATION.md` section 1

Replaced the stale "Today this repo is a source-based integration" paragraph and the wrong artifact coordinate `kioskops-sdk` with a Maven Central snippet using the correct `kiosk-ops-sdk` coordinate (matches `build.gradle.kts:167`) and a pointer to the README Installation block for the current version.

## Tests

- `QueueDaoTest`:
  - `reconcileStaleSending resets only old SENDING rows` three events, only the two older than the age gate are reset; the fresh one stays SENDING.
  - `reconcileStaleSending leaves PENDING and FAILED untouched` age gate cannot promote unrelated states.
  - `markBatchFailureNoAttemptBump preserves attempts counter` attempts at 1 (from a prior per-event failure), five batch-transient cycles, attempts still 1.
- `SyncEngineTest`:
  - `batch-level transient does not bump per-event attempts across many cycles` five events, `maxAttemptsPerEvent=3`, ten HTTP 500 cycles; `quarantinedSummaries()` is empty, `countActive()=5`.
- `CorruptionHandlingOpenHelperFactoryTest`:
  - `wrapping callback invokes corruption hook before delegate callback` ordering correctness.
  - `hook exceptions do not prevent delegate corruption recovery` defensive wrap around the host hook.

## API compatibility

All new public surface is on the `@RestrictTo(LIBRARY)` `QueueDao` and `QueueRepository` types; additive only. Baseline regenerated via `./gradlew :kiosk-ops-sdk:apiDump`.

## Local verification

`./gradlew :kiosk-ops-sdk:testDebugUnitTest :kiosk-ops-sdk:apiCheck detekt :sample-app:assembleDebug` -- all green.
