### PR TITLE
Reliability: transport timeouts, shutdown ordering, work KEEP, config flow overflow

### DIFF
--- a/kiosk-ops-sdk/api/kiosk-ops-sdk.api
+++ b/kiosk-ops-sdk/api/kiosk-ops-sdk.api
@@ -3995,21 +3995,29 @@ public final class com/sarastarquant/kioskops/sdk/sync/SyncOnceResult {
 
 public final class com/sarastarquant/kioskops/sdk/sync/SyncPolicy {
 	public static final field Companion Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy$Companion;
-	public fun <init> (ZLjava/lang/String;IZI)V
-	public synthetic fun <init> (ZLjava/lang/String;IZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLjava/lang/String;IZIJJJJ)V
+	public synthetic fun <init> (ZLjava/lang/String;IZIJJJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()I
 	public final fun component4 ()Z
 	public final fun component5 ()I
-	public final fun copy (ZLjava/lang/String;IZI)Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;
-	public static synthetic fun copy$default (Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;ZLjava/lang/String;IZIILjava/lang/Object;)Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun component8 ()J
+	public final fun component9 ()J
+	public final fun copy (ZLjava/lang/String;IZIJJJJ)Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;
+	public static synthetic fun copy$default (Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;ZLjava/lang/String;IZIJJJJILjava/lang/Object;)Lcom/sarastarquant/kioskops/sdk/sync/SyncPolicy;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBatchSize ()I
+	public final fun getCallTimeoutSeconds ()J
+	public final fun getConnectTimeoutSeconds ()J
 	public final fun getEnabled ()Z
 	public final fun getEndpointPath ()Ljava/lang/String;
 	public final fun getMaxAttemptsPerEvent ()I
+	public final fun getReadTimeoutSeconds ()J
 	public final fun getRequireUnmeteredNetwork ()Z
+	public final fun getWriteTimeoutSeconds ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
@@ -877,7 +877,11 @@ class KioskOpsSdk private constructor(
       .build()
 
     val wm = WorkManager.getInstance(appContext)
-    wm.enqueueUniquePeriodicWork(KioskOpsSyncWorker.WORK_NAME, ExistingPeriodicWorkPolicy.UPDATE, heartbeat)
+    // KEEP preserves WorkManager's exponential backoff counter across restarts; UPDATE would
+    // replace an existing run and reset backoff, effectively retrying immediately after a
+    // crash-loop. Config changes that legitimately need to re-schedule should go through a
+    // dedicated reschedule path that cancels and re-enqueues.
+    wm.enqueueUniquePeriodicWork(KioskOpsSyncWorker.WORK_NAME, ExistingPeriodicWorkPolicy.KEEP, heartbeat)
 
     // Network sync is scheduled only when explicitly enabled.
     if (cfg.syncPolicy.enabled) {
@@ -891,7 +895,7 @@ class KioskOpsSdk private constructor(
         .setConstraints(constraints)
         .build()
 
-      wm.enqueueUniquePeriodicWork(KioskOpsEventSyncWorker.WORK_NAME, ExistingPeriodicWorkPolicy.UPDATE, netSync)
+      wm.enqueueUniquePeriodicWork(KioskOpsEventSyncWorker.WORK_NAME, ExistingPeriodicWorkPolicy.KEEP, netSync)
     }
 
     // v0.3.0: Schedule diagnostics collection based on policy
@@ -1002,16 +1006,20 @@ class KioskOpsSdk private constructor(
   /**
    * Gracefully shut down the SDK.
    *
-   * Cancels background coroutine scopes, closes databases, and flushes
-   * pending audit records. After calling this method, the SDK instance
-   * is no longer usable; call [init] to create a new instance.
+   * Flushes a final audit record and telemetry event before cancelling the SDK's coroutine
+   * scope, so the teardown entry actually reaches the audit trail. After cancellation, the
+   * SDK instance is no longer usable; call [init] to create a new instance.
    *
    * @since 0.8.0
    */
   suspend fun shutdown() {
+    // Record teardown while the scope is still live. Wrap in NonCancellable in case the
+    // caller's coroutine is itself being cancelled (e.g. Activity onDestroy).
+    kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) {
+      persistentAudit.record("sdk_shutdown")
+      telemetry.emit("sdk_shutdown", mapOf("sdkVersion" to SDK_VERSION))
+    }
     sdkJob.cancel()
-    persistentAudit.record("sdk_shutdown")
-    telemetry.emit("sdk_shutdown", mapOf("sdkVersion" to SDK_VERSION))
     INSTANCE = null
   }
 
@@ -1139,9 +1147,16 @@ class KioskOpsSdk private constructor(
    * the transport security policy from the initial config.
    */
   private fun buildSecureHttpClient(): OkHttpClient {
-    val policy = cfg().transportSecurityPolicy
+    val snapshot = cfg()
+    val policy = snapshot.transportSecurityPolicy
+    val syncPolicy = snapshot.syncPolicy
 
-    var client = OkHttpClient.Builder().build()
+    var client = OkHttpClient.Builder()
+      .connectTimeout(syncPolicy.connectTimeoutSeconds, TimeUnit.SECONDS)
+      .readTimeout(syncPolicy.readTimeoutSeconds, TimeUnit.SECONDS)
+      .writeTimeout(syncPolicy.writeTimeoutSeconds, TimeUnit.SECONDS)
+      .callTimeout(syncPolicy.callTimeoutSeconds, TimeUnit.SECONDS)
+      .build()
 
     // Apply certificate pinning interceptor
     CertificatePinningInterceptor.fromPolicy(policy) { hostname, reason ->

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigManager.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigManager.kt
@@ -47,7 +47,12 @@ class RemoteConfigManager internal constructor(
   private val mutex = Mutex()
   private var lastApplyMs: Long = 0L
 
-  private val _configUpdates = MutableSharedFlow<ConfigUpdateEvent>(extraBufferCapacity = 16)
+  // DROP_OLDEST so a slow collector cannot stall the emitter; missing an older config
+  // transition in fleet telemetry is preferable to back-pressuring the manager's critical path.
+  private val _configUpdates = MutableSharedFlow<ConfigUpdateEvent>(
+    extraBufferCapacity = 16,
+    onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
+  )
 
   /**
    * Observe configuration changes as a [Flow].

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/sync/SyncPolicy.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/sync/SyncPolicy.kt
@@ -11,13 +11,37 @@ data class SyncPolicy(
   val endpointPath: String = "events/batch",
   val batchSize: Int = 50,
   /**
-   * If true, periodic sync requires unmetered network (Wi‑Fi). Useful for large payloads.
+   * If true, periodic sync requires unmetered network (Wi-Fi). Useful for large payloads.
    */
   val requireUnmeteredNetwork: Boolean = false,
   /**
    * Max attempts per event before we stop retrying automatically.
    */
   val maxAttemptsPerEvent: Int = 12,
+  /**
+   * OkHttp connect timeout in seconds. Applied to the SDK-built HTTP client; ignored when the
+   * host supplies `okHttpClientOverride` to [com.sarastarquant.kioskops.sdk.KioskOpsSdk.init].
+   * @since 1.2.0
+   */
+  val connectTimeoutSeconds: Long = 15,
+  /**
+   * OkHttp read timeout in seconds. A slow server trickling bytes can stall a worker for a
+   * long time without [callTimeoutSeconds]; this caps inter-byte wait.
+   * @since 1.2.0
+   */
+  val readTimeoutSeconds: Long = 30,
+  /**
+   * OkHttp write timeout in seconds.
+   * @since 1.2.0
+   */
+  val writeTimeoutSeconds: Long = 30,
+  /**
+   * OkHttp end-to-end call timeout in seconds. Upper bound on a single batch send including
+   * retries and redirects; prevents a hung server from pinning a sync worker until Android
+   * kills it. Set to 0 to disable.
+   * @since 1.2.0
+   */
+  val callTimeoutSeconds: Long = 60,
 ) {
   companion object {
     fun disabledDefaults() = SyncPolicy(enabled = false)

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkInitTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkInitTest.kt
@@ -89,4 +89,19 @@ class KioskOpsSdkInitTest {
     KioskOpsSdk.init(ctx, configProvider = { testConfig }, cryptoProviderOverride = NoopCryptoProvider)
     assertThat(KioskOpsSdk.SDK_VERSION).isNotEmpty()
   }
+
+  @Test
+  fun `shutdown records teardown audit before cancelling scope`() = kotlinx.coroutines.test.runTest {
+    val sdk = KioskOpsSdk.init(ctx, configProvider = { testConfig }, cryptoProviderOverride = NoopCryptoProvider)
+    val before = sdk.getAuditStatistics().totalEvents
+    sdk.shutdown()
+
+    // Re-init onto the same persistent audit DB. The sdk_shutdown record from the previous
+    // instance must be present; before the ordering fix it was dropped because sdkJob was
+    // cancelled first.
+    val sdk2 = KioskOpsSdk.init(ctx, configProvider = { testConfig }, cryptoProviderOverride = NoopCryptoProvider)
+    val after = sdk2.getAuditStatistics().totalEvents
+    // after includes: before + sdk_shutdown + sdk_initialized (from re-init).
+    assertThat(after).isAtLeast(before + 2L)
+  }
 }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigManagerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigManagerTest.kt
@@ -196,4 +196,25 @@ class RemoteConfigManagerTest {
     assertThat(result).isInstanceOf(ConfigUpdateResult.Rejected::class.java)
     assertThat((result as ConfigUpdateResult.Rejected).reason).isEqualTo(ConfigRejectionReason.PARSE_ERROR)
   }
+
+  @Test
+  fun `configUpdateFlow accepts bursts beyond buffer without hanging`() = runTest {
+    // Burst more events than the 16-slot buffer can hold. With the default SUSPEND overflow
+    // policy and a slow or absent collector, the emitter stalls; with DROP_OLDEST it rolls.
+    // Advance the clock between bundles so each one is eligible past the apply cooldown.
+    val burst = 50
+    val interval = policy.configApplyCooldownMs + 1
+    repeat(burst) { i ->
+      nowMs += interval
+      manager.processConfigBundle(
+        configBundle(i.toLong() + 10L, mapOf("k" to "$i")),
+        ConfigSource.MANAGED_CONFIG,
+      )
+    }
+
+    // Manager processed every bundle without hanging; the latest won.
+    val latest = db.configVersionDao().getActiveVersion()
+    assertThat(latest).isNotNull()
+    assertThat(latest!!.version).isEqualTo(10L + burst - 1)
+  }
 }


### PR DESCRIPTION
## Summary

Four tightly-scoped reliability tweaks, bundled so the tests and `SyncPolicy` surface land together. Each is independent behavior.

## Transport timeouts

`KioskOpsSdk.buildSecureHttpClient` used `OkHttpClient.Builder().build()` with no timeouts. OkHttp's defaults are 10s connect/read/write and no end-to-end call timeout, so a slow server trickling one byte every nine seconds can stall a sync worker indefinitely until Android kills it.

`SyncPolicy` gains four fields with fleet-safe defaults:

| Field | Default | Purpose |
| --- | --- | --- |
| `connectTimeoutSeconds` | 15 | TCP connect |
| `readTimeoutSeconds` | 30 | inter-byte read |
| `writeTimeoutSeconds` | 30 | inter-byte write |
| `callTimeoutSeconds` | 60 | end-to-end cap including retries/redirects |

The SDK-built client applies them via the standard OkHttp builder. Hosts passing their own `okHttpClientOverride` are unaffected; set `callTimeoutSeconds = 0` to disable.

## Shutdown ordering

`KioskOpsSdk.shutdown` cancelled `sdkJob` first and then called `persistentAudit.record` + `telemetry.emit` on a dead scope, so the `sdk_shutdown` audit entry silently never landed.

Now the teardown record/emit runs first under `NonCancellable` (in case the caller's own coroutine is cancelled, e.g. Activity `onDestroy`), then the scope is cancelled. Verified by `KioskOpsSdkInitTest.shutdown records teardown audit before cancelling scope`: after shutdown + re-init on the same persistent DB, `totalEvents` is at least `before + 2` (`sdk_shutdown` + the re-init's `sdk_initialized`).

## WorkManager KEEP

`applySchedulingFromConfig` used `ExistingPeriodicWorkPolicy.UPDATE` for both the heartbeat and event-sync periodic work. Every SDK init replaced the existing scheduled run and reset WorkManager's exponential backoff counter -- a crash-loop app would retry immediately after each crash instead of backing off.

Switched to `KEEP`. Legitimate reschedules on config change should go through a dedicated cancel+enqueue path in a follow-up.

## configUpdateFlow overflow

`RemoteConfigManager._configUpdates` was `MutableSharedFlow(extraBufferCapacity = 16)` with the default `onBufferOverflow = SUSPEND`. A slow or absent collector back-pressured into the applier's critical path.

Switched to `DROP_OLDEST`. Missing an older fleet-telemetry config transition is preferable to stalling the manager. Tested by bursting 50 bundles past the buffer with advancing clock to bypass apply cooldown; latest version wins.

## Minor

Removed a non-breaking hyphen in the `Wi-Fi` KDoc comment to keep the repo ASCII-only.

## Local verification

`./gradlew :kiosk-ops-sdk:testDebugUnitTest :kiosk-ops-sdk:apiCheck detekt :sample-app:assembleDebug` -- all green.

## API compatibility

Additive fields on the public `SyncPolicy` data class with defaults; existing call sites compile unchanged. Baseline regenerated.
