### PR TITLE
Update Point GitHub URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,14 +134,14 @@ jobs:
           echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
           echo "- **Maven Central**: \`com.sarastarquant.kioskops:kiosk-ops-sdk:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **GitHub Packages**: \`com.sarastarquant.kioskops:kiosk-ops-sdk:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **JitPack**: \`com.github.pzverkov:KioskOps-SDK-Android-Enterprise:${TAG}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **JitPack**: \`com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:${TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Signature Verification" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "cosign verify-blob kiosk-ops-sdk-release.aar \\" >> $GITHUB_STEP_SUMMARY
           echo "  --signature kiosk-ops-sdk-release.aar.sig \\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate kiosk-ops-sdk-release.aar.pem \\" >> $GITHUB_STEP_SUMMARY
-          echo "  --certificate-identity-regexp 'https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise' \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --certificate-identity-regexp 'https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise' \\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -661,15 +661,15 @@ Initial release of KioskOps SDK for Android Enterprise.
 - Java 17+
 - Kotlin 2.1+
 
-[0.9.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.9.0
-[0.8.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.8.0
-[0.7.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.7.0
-[0.6.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.6.0
-[0.5.3]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.3
-[0.5.2]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.2
-[0.5.1]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.1
-[0.5.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.0
-[0.4.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.4.0
-[0.3.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.3.0
-[0.2.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.2.0
-[0.1.0]: https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/releases/tag/v0.1.0
+[0.9.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.9.0
+[0.8.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.8.0
+[0.7.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.7.0
+[0.6.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.6.0
+[0.5.3]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.3
+[0.5.2]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.2
+[0.5.1]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.1
+[0.5.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.5.0
+[0.4.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.4.0
+[0.3.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.3.0
+[0.2.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.2.0
+[0.1.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@
 ### Clone and Build
 
 ```bash
-git clone https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise.git
+git clone https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise.git
 cd KioskOps-SDK-Android-Enterprise
 ./gradlew build
 ```
@@ -92,7 +92,7 @@ Report: `kiosk-ops-sdk/build/reports/lint-results-debug.html`
 
 ## Reporting Issues
 
-Use [GitHub Issues](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/issues) for:
+Use [GitHub Issues](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/issues) for:
 - Bug reports
 - Feature requests
 - Documentation improvements

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # KioskOps SDK for Android Enterprise
 
-[![Build](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/build.yml/badge.svg)](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/build.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/pzverkov/e10185573398e3034647f57ff8d61076/raw/kioskops-coverage.json)](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/build.yml)
-[![CodeQL](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/codeql.yml/badge.svg)](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/codeql.yml)
-[![Fuzz](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/fuzz.yml/badge.svg)](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/actions/workflows/fuzz.yml)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/pzverkov/KioskOps-SDK-Android-Enterprise/badge)](https://securityscorecards.dev/viewer/?uri=github.com/pzverkov/KioskOps-SDK-Android-Enterprise)
-[![JitPack](https://jitpack.io/v/pzverkov/KioskOps-SDK-Android-Enterprise.svg)](https://jitpack.io/#pzverkov/KioskOps-SDK-Android-Enterprise)
+[![Build](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/actions/workflows/build.yml/badge.svg)](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/actions/workflows/build.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/pzverkov/e10185573398e3034647f57ff8d61076/raw/kioskops-coverage.json)](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/actions/workflows/build.yml)
+[![CodeQL](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/actions/workflows/codeql.yml/badge.svg)](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/actions/workflows/codeql.yml)
+[![Fuzz](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/actions/workflows/fuzz.yml/badge.svg)](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/actions/workflows/fuzz.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise)
+[![JitPack](https://jitpack.io/v/sara-star-quant/KioskOps-SDK-Android-Enterprise.svg)](https://jitpack.io/#sara-star-quant/KioskOps-SDK-Android-Enterprise)
 [![API](https://img.shields.io/badge/API-33%2B-brightgreen.svg)](https://developer.android.com/about/versions/13)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.1-purple.svg)](https://kotlinlang.org/)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
@@ -45,7 +45,7 @@ dependencies {
 dependencyResolutionManagement {
     repositories {
         maven {
-            url = uri("https://maven.pkg.github.com/pzverkov/KioskOps-SDK-Android-Enterprise")
+            url = uri("https://maven.pkg.github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise")
             credentials {
                 username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
                 password = providers.gradleProperty("gpr.token").orNull ?: System.getenv("GITHUB_TOKEN")
@@ -72,7 +72,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.pzverkov:KioskOps-SDK-Android-Enterprise:v1.1.0")
+    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.1.0")
 }
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -423,6 +423,6 @@ Features under consideration for post-1.0 releases:
 
 Have a feature request or want to contribute?
 
-- Open an issue on [GitHub](https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/issues)
+- Open an issue on [GitHub](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/issues)
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines
 - Enterprise customers: contact support for prioritization discussions

--- a/kiosk-ops-sdk/build.gradle.kts
+++ b/kiosk-ops-sdk/build.gradle.kts
@@ -171,12 +171,12 @@ mavenPublishing {
   pom {
     name.set("KioskOps SDK")
     description.set("Enterprise-grade Android SDK for offline-first operational events, local diagnostics, and fleet-friendly observability")
-    url.set("https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise")
+    url.set("https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise")
 
     licenses {
       license {
         name.set("Business Source License 1.1")
-        url.set("https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise/blob/main/LICENSE")
+        url.set("https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/blob/main/LICENSE")
       }
     }
 
@@ -189,9 +189,9 @@ mavenPublishing {
     }
 
     scm {
-      url.set("https://github.com/pzverkov/KioskOps-SDK-Android-Enterprise")
-      connection.set("scm:git:git://github.com/pzverkov/KioskOps-SDK-Android-Enterprise.git")
-      developerConnection.set("scm:git:ssh://github.com/pzverkov/KioskOps-SDK-Android-Enterprise.git")
+      url.set("https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise")
+      connection.set("scm:git:git://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise.git")
+      developerConnection.set("scm:git:ssh://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise.git")
     }
   }
 }
@@ -202,7 +202,7 @@ afterEvaluate {
     repositories {
       maven {
         name = "GitHubPackages"
-        url = uri("https://maven.pkg.github.com/pzverkov/KioskOps-SDK-Android-Enterprise")
+        url = uri("https://maven.pkg.github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise")
         credentials {
           username = System.getenv("GITHUB_ACTOR") ?: findProperty("gpr.user")?.toString()
           password = System.getenv("GITHUB_TOKEN") ?: findProperty("gpr.token")?.toString()


### PR DESCRIPTION
## Summary

The repo new integrators and fleet-telemetry dashboards were seeing inconsistent across badges, docs, and POM metadata. This PR points every user-facing GitHub URL.

## What's changed

- **README.md**: six workflow/badge URLs, the GitHub Packages publish URL, and the JitPack install coordinate. 
- **kiosk-ops-sdk/build.gradle.kts** POM metadata: project URL, license URL, SCM URLs, GitHub Packages publish URL. Already-published Maven Central artifacts (v0.1.0 through v1.1.0) are immutable and will always reference `pzverkov` in their frozen SCM block; this change takes effect for the next release.
- **CHANGELOG.md**: release-tag compare links.
- **ROADMAP.md**: issue link.
- **CONTRIBUTING.md**: clone URL and issues URL.
- **.github/workflows/release.yml**: the post-release summary now prints the JitPack coordinate and cosign verification regex under the new owner. Verifiers of pre-rename artifacts will still need the old regex, which is the expected behavior when a repo moves.

## Intentionally left alone

- **README coverage badge** gist URL. The existing gist still resolves.
- **kiosk-ops-sdk POM** `developer id.
- **.github/SECURITY.md** contact email.

## Maven Central is unaffected

The Maven Central groupId `com.sarastarquant.kioskops` is tied to the `sarastarquant.com` domain, not the GitHub owner. The install snippet in README Option A is unchanged; existing consumers keep building.

## Local verification

`./gradlew :kiosk-ops-sdk:assembleDebug detekt` -- green.

## No code changes

Pure metadata/URL update; no source or test changes, no API surface changes.
