### PR TITLE
HKDF-SHA256 deterministic derivation + FileSink size mutex

### DIFF
--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/Hkdf.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/Hkdf.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.crypto
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+private const val HMAC_SHA256 = "HmacSHA256"
+private const val SHA256_LEN = 32
+private const val MAX_HKDF_OUT_BLOCKS = 255
+
+/**
+ * HKDF-Extract + HKDF-Expand (RFC 5869) with HMAC-SHA256.
+ *
+ * Used where a deterministic key derivation is needed from arbitrary input keying material
+ * (IKM) with domain separation via [info] and optional [salt]. Unlike PBKDF2, HKDF is
+ * designed for key derivation from high-entropy keys (not passwords) and is standardised
+ * with rigid input/output semantics, which makes it the correct primitive for reproducible
+ * idempotency-key generation, subkey derivation, and similar internal flows.
+ *
+ * @param ikm Input keying material.
+ * @param salt HKDF salt; empty salt is allowed and canonicalises to [SHA256_LEN] zero bytes.
+ * @param info Context / label for domain separation.
+ * @param outLen Output length in bytes; must satisfy `1 <= outLen <= 255 * HashLen = 8160`.
+ * @return [outLen] derived bytes.
+ *
+ * @since 1.2.0
+ */
+internal fun hkdfSha256(
+  ikm: ByteArray,
+  salt: ByteArray,
+  info: ByteArray,
+  outLen: Int,
+): ByteArray {
+  require(outLen in 1..(MAX_HKDF_OUT_BLOCKS * SHA256_LEN)) { "HKDF outLen out of range" }
+
+  val mac = Mac.getInstance(HMAC_SHA256)
+  // Extract: PRK = HMAC(salt or zero, IKM). RFC 5869 allows an empty salt, canonicalised
+  // to HashLen zero bytes.
+  val extractSalt = if (salt.isEmpty()) ByteArray(SHA256_LEN) else salt
+  mac.init(SecretKeySpec(extractSalt, HMAC_SHA256))
+  val prk = mac.doFinal(ikm)
+
+  // Expand: T = T(1) | T(2) | ... | T(n); T(i) = HMAC(PRK, T(i-1) | info | i).
+  mac.init(SecretKeySpec(prk, HMAC_SHA256))
+  val blocks = (outLen + SHA256_LEN - 1) / SHA256_LEN
+  val out = ByteArray(blocks * SHA256_LEN)
+  var prev = ByteArray(0)
+  for (i in 1..blocks) {
+    mac.reset()
+    mac.update(prev)
+    mac.update(info)
+    mac.update(i.toByte())
+    prev = mac.doFinal()
+    prev.copyInto(out, (i - 1) * SHA256_LEN)
+  }
+  return out.copyOfRange(0, outLen)
+}

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/SecureKeyDerivation.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/SecureKeyDerivation.kt
@@ -103,37 +103,32 @@ class SecureKeyDerivation(
   }
 
   /**
-   * Derive a deterministic key from input material.
+   * Derive a deterministic key from input material using HKDF (RFC 5869) with HMAC-SHA256.
    *
-   * This is used for deterministic idempotency key generation where
-   * the same input should always produce the same output.
+   * Used for reproducible derivations (e.g., idempotency keys) where the same IKM, salt,
+   * and context must always yield the same output. HKDF is the correct primitive for this:
+   * PBKDF2 is designed for password stretching and routing raw bytes through a char-based
+   * PBEKeySpec is lossy across provider implementations.
    *
-   * @param inputMaterial The input bytes to derive from.
-   * @param context A context string to domain-separate the derivation.
-   * @param salt Fixed salt for deterministic output.
-   * @return The derived key bytes.
+   * Output length matches [KeyDerivationConfig.keyLengthBits] (must be a multiple of 8).
+   *
+   * @param inputMaterial Input keying material (IKM).
+   * @param context Context / info parameter for domain separation.
+   * @param salt HKDF salt; public, should be non-empty for best PRK quality.
+   * @return The derived bytes, length `keyLengthBits / 8`.
    */
   fun deriveDeterministic(
     inputMaterial: ByteArray,
     context: String,
     salt: ByteArray,
   ): ByteArray {
-    // Combine input material with context for domain separation
-    val combined = inputMaterial + context.toByteArray(Charsets.UTF_8)
-
-    val spec = PBEKeySpec(
-      String(combined, Charsets.ISO_8859_1).toCharArray(),
-      salt,
-      config.iterationCount,
-      config.keyLengthBits,
+    require(config.keyLengthBits % 8 == 0) { "keyLengthBits must be a multiple of 8" }
+    return hkdfSha256(
+      ikm = inputMaterial,
+      salt = salt,
+      info = context.toByteArray(Charsets.UTF_8),
+      outLen = config.keyLengthBits / 8,
     )
-
-    return try {
-      val factory = SecretKeyFactory.getInstance(config.algorithm)
-      factory.generateSecret(spec).encoded
-    } finally {
-      spec.clearPassword()
-    }
   }
 }
 

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/observability/logging/FileSink.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/observability/logging/FileSink.kt
@@ -7,7 +7,6 @@ package com.sarastarquant.kioskops.sdk.observability.logging
 
 import com.sarastarquant.kioskops.sdk.observability.LogLevel
 import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * In-memory ring buffer logging sink with file persistence support.
@@ -34,16 +33,23 @@ class FileSink(
 ) : LoggingSink {
 
   private val buffer = ConcurrentLinkedDeque<LogEntry>()
-  private val size = AtomicInteger(0)
+  // Guards the (buffer, size) pair as a single view. The prior AtomicInteger + lock-free
+  // trim was racy: the trim loop read a stale captured size so a single over-capacity emit
+  // drained the whole buffer, and concurrent emits could let size drift negative because
+  // pollFirst returning null skipped the decrement while a concurrent emit had already
+  // incremented. Serialising emit and trim under one monitor is cheap (emit is not hot)
+  // and gives us a single well-defined invariant: size == buffer.size.
+  private val lock = Any()
+
+  @Volatile
+  private var bufferSize: Int = 0
 
   override fun emit(entry: LogEntry) {
-    buffer.addLast(entry)
-    val currentSize = size.incrementAndGet()
-
-    // Trim if over capacity
-    while (currentSize > maxLines && buffer.isNotEmpty()) {
-      if (buffer.pollFirst() != null) {
-        size.decrementAndGet()
+    synchronized(lock) {
+      buffer.addLast(entry)
+      bufferSize++
+      while (bufferSize > maxLines) {
+        if (buffer.pollFirst() != null) bufferSize-- else break
       }
     }
   }
@@ -112,14 +118,16 @@ class FileSink(
   /**
    * Get current buffer size.
    */
-  fun size(): Int = size.get()
+  fun size(): Int = bufferSize
 
   /**
    * Clear all buffered entries.
    */
   fun clear() {
-    buffer.clear()
-    size.set(0)
+    synchronized(lock) {
+      buffer.clear()
+      bufferSize = 0
+    }
   }
 
   /**

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/SecureKeyDerivationTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/SecureKeyDerivationTest.kt
@@ -111,4 +111,49 @@ class SecureKeyDerivationTest {
     val result = derivation.deriveKey("password")
     assertThat(result.key.algorithm).isEqualTo("AES")
   }
+
+  @Test
+  fun `HKDF matches RFC 5869 test vector 1 SHA-256`() {
+    // RFC 5869 Appendix A.1
+    val ikm = ByteArray(22) { 0x0b }
+    val salt = byteArrayOf(
+      0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+      0x08, 0x09, 0x0a, 0x0b, 0x0c,
+    )
+    val info = byteArrayOf(
+      0xf0.toByte(), 0xf1.toByte(), 0xf2.toByte(), 0xf3.toByte(),
+      0xf4.toByte(), 0xf5.toByte(), 0xf6.toByte(), 0xf7.toByte(),
+      0xf8.toByte(), 0xf9.toByte(),
+    )
+    val expected = hexToBytes(
+      "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+    )
+
+    val out = hkdfSha256(ikm, salt, info, expected.size)
+    assertThat(out).isEqualTo(expected)
+  }
+
+  @Test
+  fun `HKDF empty salt still produces deterministic output`() {
+    val ikm = "input".toByteArray()
+    val out1 = hkdfSha256(ikm, salt = ByteArray(0), info = "ctx".toByteArray(), outLen = 32)
+    val out2 = hkdfSha256(ikm, salt = ByteArray(0), info = "ctx".toByteArray(), outLen = 32)
+    assertThat(out1).isEqualTo(out2)
+    assertThat(out1).hasLength(32)
+  }
+
+  @Test
+  fun `deriveDeterministic output length matches keyLengthBits`() {
+    val input = "payload".toByteArray()
+    val salt = ByteArray(16) { it.toByte() }
+    val out = derivation.deriveDeterministic(input, "idempotency", salt)
+    assertThat(out.size * 8).isEqualTo(KeyDerivationConfig.fastForTesting().keyLengthBits)
+  }
+
+  private fun hexToBytes(hex: String): ByteArray {
+    require(hex.length % 2 == 0)
+    return ByteArray(hex.length / 2) { i ->
+      hex.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+    }
+  }
 }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/observability/logging/FileSinkTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/observability/logging/FileSinkTest.kt
@@ -34,10 +34,31 @@ class FileSinkTest {
     for (i in 1..5) {
       sink.emit(entry(message = "msg-$i"))
     }
-    // After 5 emits with capacity 3, entries should be trimmed to at most 3
-    val entries = sink.getEntries()
-    assertThat(entries.size).isAtMost(4) // ConcurrentLinkedDeque may have 1 extra due to trim timing
-    assertThat(entries.size).isGreaterThan(0)
+    assertThat(sink.getEntries()).hasSize(3)
+    assertThat(sink.size()).isEqualTo(3)
+  }
+
+  @Test
+  fun `concurrent emit keeps size in step with buffer and never goes negative`() {
+    val sink = FileSink(maxLines = 50)
+    val threads = 8
+    val perThread = 200
+    val pool = java.util.concurrent.Executors.newFixedThreadPool(threads)
+    val latch = java.util.concurrent.CountDownLatch(threads)
+    repeat(threads) { t ->
+      pool.submit {
+        repeat(perThread) { i -> sink.emit(entry(message = "t$t-$i")) }
+        latch.countDown()
+      }
+    }
+    latch.await()
+    pool.shutdown()
+
+    assertThat(sink.size()).isEqualTo(sink.getEntries().size)
+    assertThat(sink.size()).isAtLeast(0)
+    assertThat(sink.size()).isAtMost(50)
+    // With 1600 writes and cap 50, the buffer must be at capacity, not drained.
+    assertThat(sink.size()).isEqualTo(50)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two independent correctness fixes from the v1.0 audit follow-up list, bundled because they share the same risk profile (small, local, no public surface change).

## HKDF for `SecureKeyDerivation.deriveDeterministic`

The previous implementation combined input material + context into a byte array, round-tripped it through an `ISO-8859-1` `String`, and fed it into `PBKDF2` via `PBEKeySpec`. Two problems:

1. **Wrong primitive.** PBKDF2 is designed for password stretching, high iteration counts to slow down brute-force attacks on low-entropy inputs. Deterministic key derivation from high-entropy keying material wants a fast KDF with rigid input semantics, not a slow one built for passwords.
2. **Lossy bridge.** `PBEKeySpec`'s char-to-byte conversion is implementation-defined across JCE providers; `ISO-8859-1` is a 1:1 byte-to-char map on paper but provider quirks can drop high bytes. The round-trip was not a reliable way to pass raw bytes through.

Replaced with **HKDF (RFC 5869) with HMAC-SHA256** in a new top-level `Hkdf.kt` helper:

- `hkdfSha256(ikm, salt, info, outLen)` performs HKDF-Extract + HKDF-Expand.
- `deriveDeterministic` delegates to it with `info = context.toByteArray(UTF_8)` and `outLen = keyLengthBits / 8`.
- Verified against **RFC 5869 Appendix A.1** test vector.
- `hkdfSha256` is `internal` and lives outside any class, so no `Companion` lands in the public API dump.

**Behavior change:** the output bytes differ from the old PBKDF2 path. `deriveDeterministic` has no production callers today (only tests), so this is safe. Any future consumer builds on a clean primitive.

## `FileSink` size counter mutex

Two defects in the pre-existing `AtomicInteger + ConcurrentLinkedDeque` implementation:

1. **Drain on overflow.** The trim loop captured the post-increment size into a local `val currentSize` and then read that stale value every iteration. A single over-capacity emit would therefore drain the entire buffer to empty rather than trimming by one:

    ```kotlin
    val currentSize = size.incrementAndGet()  // local, never updated
    while (currentSize > maxLines && buffer.isNotEmpty()) {
      if (buffer.pollFirst() != null) size.decrementAndGet()
      // loop re-checks `currentSize` (still post-increment value), drains everything
    }
    ```

2. **Negative counter under concurrent emit.** `pollFirst()` returning `null` skipped the `decrement` while a concurrent `emit` had already incremented; over many interleavings the counter drifted below zero and desynced from `buffer.size`.

Replaced with a single `synchronized(lock)` block guarding the `(buffer, bufferSize)` pair as a unit. `size()` reads a `@Volatile Int` for lock-free reads. The trim loop re-reads `bufferSize` each iteration.

### Tests

- `SecureKeyDerivationTest` adds:
  - `HKDF matches RFC 5869 test vector 1 SHA-256`, exact byte match against the RFC appendix.
  - `HKDF empty salt still produces deterministic output`.
  - `deriveDeterministic output length matches keyLengthBits`.
- `FileSinkTest`:
  - Tightened `respects maxLines capacity` from the old "at most 4 when max=3" sloppy assertion to exact `hasSize(3)`.
  - Added `concurrent emit keeps size in step with buffer and never goes negative`, 8 threads, 200 writes each, cap=50; asserts `size == buffer.size`, bounds `[0, 50]`, and finalises at exactly 50.

## API compatibility

No change to the public API dump. `hkdfSha256` is module-internal; `SecureKeyDerivation.deriveDeterministic` keeps its signature.

## Local verification

`./gradlew :kiosk-ops-sdk:testDebugUnitTest :kiosk-ops-sdk:apiCheck detekt :sample-app:assembleDebug` all green.
