### PR TITLE
Preset transport-security audit. PilotDefaults @RequiresOptIn

### DIFF
--- a/kiosk-ops-sdk/api/kiosk-ops-sdk.api
+++ b/kiosk-ops-sdk/api/kiosk-ops-sdk.api
@@ -2141,6 +2141,9 @@ public final class com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolic
 	public final fun pilotDefaults ()Lcom/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy;
 }
 
+public abstract interface annotation class com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy$PilotConfig : java/lang/annotation/Annotation {
+}
+
 public abstract class com/sarastarquant/kioskops/sdk/fleet/config/db/ConfigDatabase : androidx/room/RoomDatabase {
 	public static final field Companion Lcom/sarastarquant/kioskops/sdk/fleet/config/db/ConfigDatabase$Companion;
 	public fun <init> ()V

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsConfig.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsConfig.kt
@@ -103,28 +103,68 @@ data class KioskOpsConfig @JvmOverloads constructor(
 
   companion object {
     /**
+     * Log an ERROR if a high-security preset is used against an HTTPS endpoint without
+     * either certificate pinning or Certificate Transparency enabled. FedRAMP, NIST 800-171
+     * (CUI), CJIS, and ASD Essential Eight all expect transport-layer integrity controls
+     * beyond the CA system; a high-security preset with default [TransportSecurityPolicy]
+     * silently relies on the device trust store alone, which is the wrong default for these
+     * compliance targets.
+     *
+     * This is advisory logging only (no exception) because the preset may be used for
+     * testing or staging against an intentionally-unpinned endpoint. For production, set
+     * [TransportSecurityPolicy.certificatePins] or
+     * [TransportSecurityPolicy.certificateTransparencyEnabled] on the returned config via
+     * `.copy(transportSecurityPolicy = ...)`.
+     *
+     * @since 1.2.0
+     */
+    private fun warnIfHttpsWithoutTransportSecurity(presetName: String, baseUrl: String) {
+      if (!baseUrl.startsWith("https://", ignoreCase = true)) return
+      val policy = TransportSecurityPolicy()
+      if (policy.certificatePins.isEmpty() && !policy.certificateTransparencyEnabled) {
+        android.util.Log.e(
+          "KioskOpsConfig",
+          "$presetName used with HTTPS baseUrl but no certificate pins or Certificate " +
+            "Transparency are configured. Compliance targets for this preset expect " +
+            "transport-layer integrity beyond the device trust store. Set " +
+            "TransportSecurityPolicy.certificatePins or " +
+            "TransportSecurityPolicy.certificateTransparencyEnabled on the returned config.",
+        )
+      }
+    }
+
+    /**
      * FedRAMP-compliant defaults (NIST 800-53).
      *
      * Enables all security features: validation (strict), PII detection (reject),
      * field encryption, anomaly detection, signed audit, and 365-day audit retention.
      *
+     * **Transport security**: logs an ERROR if [baseUrl] is HTTPS without
+     * [TransportSecurityPolicy.certificatePins] or
+     * [TransportSecurityPolicy.certificateTransparencyEnabled]; see
+     * [warnIfHttpsWithoutTransportSecurity]. The returned config still uses defaults; set
+     * transport security on the returned object via `.copy(transportSecurityPolicy = ...)`.
+     *
      * @since 0.5.0
      */
-    fun fedRampDefaults(baseUrl: String, locationId: String) = KioskOpsConfig(
-      baseUrl = baseUrl,
-      locationId = locationId,
-      kioskEnabled = true,
-      securityPolicy = SecurityPolicy.highSecurityDefaults(),
-      retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
-        retainAuditDays = 365,
-        minimumAuditRetentionDays = 365,
-      ),
-      validationPolicy = ValidationPolicy.strictDefaults(),
-      piiPolicy = PiiPolicy.rejectDefaults(),
-      fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
-      dataClassificationPolicy = DataClassificationPolicy.enabledDefaults(),
-      anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
-    )
+    fun fedRampDefaults(baseUrl: String, locationId: String): KioskOpsConfig {
+      warnIfHttpsWithoutTransportSecurity("fedRampDefaults", baseUrl)
+      return KioskOpsConfig(
+        baseUrl = baseUrl,
+        locationId = locationId,
+        kioskEnabled = true,
+        securityPolicy = SecurityPolicy.highSecurityDefaults(),
+        retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
+          retainAuditDays = 365,
+          minimumAuditRetentionDays = 365,
+        ),
+        validationPolicy = ValidationPolicy.strictDefaults(),
+        piiPolicy = PiiPolicy.rejectDefaults(),
+        fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
+        dataClassificationPolicy = DataClassificationPolicy.enabledDefaults(),
+        anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
+      )
+    }
 
     /**
      * GDPR-compliant defaults.
@@ -157,25 +197,28 @@ data class KioskOpsConfig @JvmOverloads constructor(
      *
      * @since 0.8.0
      */
-    fun cuiDefaults(baseUrl: String, locationId: String) = KioskOpsConfig(
-      baseUrl = baseUrl,
-      locationId = locationId,
-      kioskEnabled = true,
-      securityPolicy = SecurityPolicy.highSecurityDefaults(),
-      retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
-        retainAuditDays = 365,
-        minimumAuditRetentionDays = 365,
-      ),
-      validationPolicy = ValidationPolicy.strictDefaults(),
-      piiPolicy = PiiPolicy.rejectDefaults(),
-      fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
-      dataClassificationPolicy = DataClassificationPolicy.enabledDefaults().copy(
-        defaultClassification = DataClassification.CONFIDENTIAL,
-      ),
-      anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
-      databaseEncryptionPolicy = DatabaseEncryptionPolicy.enabledDefaults(),
-      requireDataRightsAuthorization = true,
-    )
+    fun cuiDefaults(baseUrl: String, locationId: String): KioskOpsConfig {
+      warnIfHttpsWithoutTransportSecurity("cuiDefaults", baseUrl)
+      return KioskOpsConfig(
+        baseUrl = baseUrl,
+        locationId = locationId,
+        kioskEnabled = true,
+        securityPolicy = SecurityPolicy.highSecurityDefaults(),
+        retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
+          retainAuditDays = 365,
+          minimumAuditRetentionDays = 365,
+        ),
+        validationPolicy = ValidationPolicy.strictDefaults(),
+        piiPolicy = PiiPolicy.rejectDefaults(),
+        fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
+        dataClassificationPolicy = DataClassificationPolicy.enabledDefaults().copy(
+          defaultClassification = DataClassification.CONFIDENTIAL,
+        ),
+        anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
+        databaseEncryptionPolicy = DatabaseEncryptionPolicy.enabledDefaults(),
+        requireDataRightsAuthorization = true,
+      )
+    }
 
     /**
      * CJIS Security Policy defaults for law enforcement kiosk deployments.
@@ -189,25 +232,28 @@ data class KioskOpsConfig @JvmOverloads constructor(
      *
      * @since 0.8.0
      */
-    fun cjisDefaults(baseUrl: String, locationId: String) = KioskOpsConfig(
-      baseUrl = baseUrl,
-      locationId = locationId,
-      kioskEnabled = true,
-      securityPolicy = SecurityPolicy.highSecurityDefaults(),
-      retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
-        retainAuditDays = 365,
-        minimumAuditRetentionDays = 365,
-      ),
-      validationPolicy = ValidationPolicy.strictDefaults(),
-      piiPolicy = PiiPolicy.rejectDefaults(),
-      fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
-      dataClassificationPolicy = DataClassificationPolicy.enabledDefaults().copy(
-        defaultClassification = DataClassification.CONFIDENTIAL,
-      ),
-      anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
-      databaseEncryptionPolicy = DatabaseEncryptionPolicy.enabledDefaults(),
-      requireDataRightsAuthorization = true,
-    )
+    fun cjisDefaults(baseUrl: String, locationId: String): KioskOpsConfig {
+      warnIfHttpsWithoutTransportSecurity("cjisDefaults", baseUrl)
+      return KioskOpsConfig(
+        baseUrl = baseUrl,
+        locationId = locationId,
+        kioskEnabled = true,
+        securityPolicy = SecurityPolicy.highSecurityDefaults(),
+        retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
+          retainAuditDays = 365,
+          minimumAuditRetentionDays = 365,
+        ),
+        validationPolicy = ValidationPolicy.strictDefaults(),
+        piiPolicy = PiiPolicy.rejectDefaults(),
+        fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
+        dataClassificationPolicy = DataClassificationPolicy.enabledDefaults().copy(
+          defaultClassification = DataClassification.CONFIDENTIAL,
+        ),
+        anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
+        databaseEncryptionPolicy = DatabaseEncryptionPolicy.enabledDefaults(),
+        requireDataRightsAuthorization = true,
+      )
+    }
 
     /**
      * ASD Essential Eight defaults for Australian government deployments.
@@ -218,20 +264,23 @@ data class KioskOpsConfig @JvmOverloads constructor(
      *
      * @since 0.8.0
      */
-    fun asdEssentialEightDefaults(baseUrl: String, locationId: String) = KioskOpsConfig(
-      baseUrl = baseUrl,
-      locationId = locationId,
-      kioskEnabled = true,
-      securityPolicy = SecurityPolicy.highSecurityDefaults(),
-      retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
-        retainAuditDays = 365,
-        minimumAuditRetentionDays = 365,
-      ),
-      validationPolicy = ValidationPolicy.strictDefaults(),
-      piiPolicy = PiiPolicy.redactDefaults(),
-      fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
-      dataClassificationPolicy = DataClassificationPolicy.enabledDefaults(),
-      anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
-    )
+    fun asdEssentialEightDefaults(baseUrl: String, locationId: String): KioskOpsConfig {
+      warnIfHttpsWithoutTransportSecurity("asdEssentialEightDefaults", baseUrl)
+      return KioskOpsConfig(
+        baseUrl = baseUrl,
+        locationId = locationId,
+        kioskEnabled = true,
+        securityPolicy = SecurityPolicy.highSecurityDefaults(),
+        retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
+          retainAuditDays = 365,
+          minimumAuditRetentionDays = 365,
+        ),
+        validationPolicy = ValidationPolicy.strictDefaults(),
+        piiPolicy = PiiPolicy.redactDefaults(),
+        fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
+        dataClassificationPolicy = DataClassificationPolicy.enabledDefaults(),
+        anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
+      )
+    }
   }
 }

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicy.kt
@@ -32,6 +32,25 @@ data class RemoteConfigPolicy(
   val maxRetainedVersions: Int = 5,
   val configApplyCooldownMs: Long = 60_000L,
 ) {
+  /**
+   * Opt-in marker for configuration profiles that are explicitly not production-ready.
+   * Currently gates [RemoteConfigPolicy.pilotDefaults], which disables signature
+   * verification and lowers minimum-version enforcement. Call sites must add
+   * `@OptIn(PilotConfig::class)` or propagate `@PilotConfig` to acknowledge they are
+   * choosing a lower-security posture. See KDoc on [pilotDefaults] for details.
+   *
+   * @since 1.2.0
+   */
+  @RequiresOptIn(
+    message = "This configuration disables signature verification and lowers version " +
+      "enforcement; it is intended for staging, pilots, and integration testing. Do not " +
+      "use in production. Acknowledge with @OptIn(PilotConfig::class).",
+    level = RequiresOptIn.Level.WARNING,
+  )
+  @Retention(AnnotationRetention.BINARY)
+  @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
+  annotation class PilotConfig
+
   companion object {
     /**
      * Disabled defaults - remote config is opt-in.
@@ -53,7 +72,16 @@ data class RemoteConfigPolicy(
 
     /**
      * Pilot defaults for testing without signature verification.
+     *
+     * **NOT FOR PRODUCTION.** Disables `requireSignedConfig` and accepts any
+     * `minimumConfigVersion`, which means a malicious managed-config push can install a
+     * policy that relaxes PII handling, disables encryption, or redirects baseUrl. The
+     * returned policy is still safer than disabling remote config entirely (A/B testing
+     * + version monotonicity still apply) but is inappropriate for any deployment that
+     * handles real user data. Gated by [PilotConfig] since 1.2.0; callers must add
+     * `@OptIn(RemoteConfigPolicy.PilotConfig::class)` to acknowledge.
      */
+    @PilotConfig
     fun pilotDefaults() = RemoteConfigPolicy(
       enabled = true,
       minimumConfigVersion = 0L,

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigManagerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigManagerTest.kt
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(RemoteConfigPolicy.PilotConfig::class)
 @RunWith(RobolectricTestRunner::class)
 class RemoteConfigManagerTest {
 

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicyTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/fleet/config/RemoteConfigPolicyTest.kt
@@ -15,6 +15,7 @@ import org.robolectric.RobolectricTestRunner
  *
  * Security (BSI APP.4.4.A5): Validates policy defaults ensure safe configuration.
  */
+@OptIn(RemoteConfigPolicy.PilotConfig::class)
 @RunWith(RobolectricTestRunner::class)
 class RemoteConfigPolicyTest {
 


### PR DESCRIPTION
## Summary

Two v1.0 audit follow-ups that both deal with dangerous defaults escaping notice in production.

## High-security preset transport audit

`fedRampDefaults`, `cuiDefaults`, `cjisDefaults`, and `asdEssentialEightDefaults` now log `android.util.Log.e` when the caller supplies an HTTPS `baseUrl` but leaves `TransportSecurityPolicy` at its defaults (no certificate pins, CT disabled).

FedRAMP / NIST 800-171 / CJIS / ASD Essential Eight all expect transport-layer integrity beyond the device CA trust store; silently relying on the system trust anchors alone is the wrong default for a preset named after one of those regimes. Before this PR, a developer calling `KioskOpsConfig.fedRampDefaults("https://api.example.com", "STORE")` got a config that claims compliance defaults while actually leaving the transport wide open to any CA in the device trust store.

The log is advisory only (no exception). The preset may legitimately be used for staging or integration tests against an unpinned endpoint; we prefer a loud signal in logcat over forcing callers to configure transport security before they can run a smoke test.

Fix for callers:

```kotlin
val cfg = KioskOpsConfig.fedRampDefaults("https://api.example.com", "STORE")
  .copy(
    transportSecurityPolicy = TransportSecurityPolicy(
      certificatePins = listOf(CertificatePin("api.example.com", listOf("sha256/..."))),
    ),
  )
```

## `pilotDefaults` requires opt-in

`RemoteConfigPolicy.pilotDefaults` disables `requireSignedConfig` and accepts any `minimumConfigVersion`, which means a malicious managed-config push can install a policy that relaxes PII handling, disables encryption, or redirects `baseUrl`. That is fine for staging but dangerous as a named default a production codebase might reach for.

Added a nested `@PilotConfig` annotation on `RemoteConfigPolicy` with `@RequiresOptIn(Level.WARNING)`. Callers now have to write `@OptIn(RemoteConfigPolicy.PilotConfig::class)` to acknowledge the lower-security posture. The KDoc on `pilotDefaults` spells out precisely what the relaxed posture lets through.

Test files that exercise `pilotDefaults` (`RemoteConfigManagerTest`, `RemoteConfigPolicyTest`) are annotated at the class level. No production call sites exist in the SDK or sample-app, so there is no further fan-out needed for this PR.

## API compatibility

One addition: `RemoteConfigPolicy.PilotConfig` nested annotation. Baseline regenerated. No removals, no signature changes.

Existing callers of `RemoteConfigPolicy.pilotDefaults` will now see a WARNING-level opt-in requirement. Code that ignores warnings continues to compile; code that elevates warnings to errors will need the `@OptIn` marker, which is the intended behavior.

## Local verification

`./gradlew :kiosk-ops-sdk:testDebugUnitTest :kiosk-ops-sdk:apiCheck detekt :sample-app:assembleDebug` -> all green.
