### PR TITLE
Cap lastError length and diagnostics export size

### DIFF
--- a/kiosk-ops-sdk/api/kiosk-ops-sdk.api
+++ b/kiosk-ops-sdk/api/kiosk-ops-sdk.api
@@ -1630,9 +1630,10 @@ public final class com/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsExporte
 public final class com/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy {
 	public static final field Companion Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$Companion;
 	public fun <init> ()V
-	public fun <init> (ZLcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$ScheduleType;IIZIJZZ)V
-	public synthetic fun <init> (ZLcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$ScheduleType;IIZIJZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$ScheduleType;IIZIJZZJ)V
+	public synthetic fun <init> (ZLcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$ScheduleType;IIZIJZZJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
+	public final fun component10 ()J
 	public final fun component2 ()Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$ScheduleType;
 	public final fun component3 ()I
 	public final fun component4 ()I
@@ -1641,11 +1642,12 @@ public final class com/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedul
 	public final fun component7 ()J
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy (ZLcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$ScheduleType;IIZIJZZ)Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;
-	public static synthetic fun copy$default (Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;ZLcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$ScheduleType;IIZIJZZILjava/lang/Object;)Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;
+	public final fun copy (ZLcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$ScheduleType;IIZIJZZJ)Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;
+	public static synthetic fun copy$default (Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;ZLcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy$ScheduleType;IIZIJZZJILjava/lang/Object;)Lcom/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAutoUploadEnabled ()Z
 	public final fun getIncludeExtendedPosture ()Z
+	public final fun getMaxExportBytes ()J
 	public final fun getMaxRemoteTriggersPerDay ()I
 	public final fun getRemoteTriggerCooldownMs ()J
 	public final fun getRemoteTriggerEnabled ()Z

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsExporter.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsExporter.kt
@@ -48,7 +48,11 @@ class DiagnosticsExporter(
     val policyHash = policyHashProvider()
     val quarantined = quarantinedSummaryProvider()
 
-    ZipOutputStream(BufferedOutputStream(zipFile.outputStream())).use { zos ->
+    val maxBytes = cfg.diagnosticsSchedulePolicy.maxExportBytes
+    val counting = CountingOutputStream(BufferedOutputStream(zipFile.outputStream()))
+    val skipped = mutableListOf<String>()
+
+    ZipOutputStream(counting).use { zos ->
       // Health snapshot
       val includeDeviceId = cfg.telemetryPolicy.includeDeviceId
       val snapshot = HealthSnapshot(
@@ -88,27 +92,86 @@ class DiagnosticsExporter(
         "bundleContainsEncryptedEntries" to cfg.securityPolicy.encryptDiagnosticsBundle.toString(),
       )
 
+      // Critical small entries are never truncated.
       writeEntry(zos, "manifest.json", json.encodeToString(manifest).toByteArray(Charsets.UTF_8))
       writeEntry(zos, "health_snapshot.json", json.encodeToString(snapshot).toByteArray(Charsets.UTF_8))
       writeEntry(zos, "queue/quarantined_summaries.json", json.encodeToString(quarantined).toByteArray(Charsets.UTF_8))
 
       // Logs (encrypted export if enabled)
       val logFile = logExporter.export()
-      addFile(zos, "logs/${logFile.name}", logFile)
-
-      // Telemetry
-      for (f in telemetry.listFiles()) {
-        addFile(zos, "telemetry/${f.name}", f)
+      if (!addFileCapped(zos, "logs/${logFile.name}", logFile, counting, maxBytes)) {
+        skipped.add("logs/${logFile.name}")
       }
 
-      // Audit
+      for (f in telemetry.listFiles()) {
+        if (!addFileCapped(zos, "telemetry/${f.name}", f, counting, maxBytes)) {
+          skipped.add("telemetry/${f.name}")
+        }
+      }
+
       for (f in audit.listFiles()) {
-        addFile(zos, "audit/${f.name}", f)
+        if (!addFileCapped(zos, "audit/${f.name}", f, counting, maxBytes)) {
+          skipped.add("audit/${f.name}")
+        }
+      }
+
+      if (skipped.isNotEmpty()) {
+        val marker = buildString {
+          append("Diagnostics export truncated to stay within maxExportBytes=$maxBytes.\n")
+          append("Omitted entries:\n")
+          for (path in skipped) append("  - ").append(path).append('\n')
+        }
+        writeEntry(zos, "truncation.txt", marker.toByteArray(Charsets.UTF_8))
       }
     }
 
+    if (skipped.isNotEmpty()) {
+      logs.w("Diag", "Export truncated: ${skipped.size} entries omitted to stay within ${maxBytes}B")
+    }
     logs.i("Diag", "Exported diagnostics: ${zipFile.name} (${zipFile.length()} bytes)")
     return zipFile
+  }
+
+  /**
+   * Add a file to the ZIP only if doing so would keep `counting.bytesWritten` within
+   * [maxBytes]. Returns `false` if the file was skipped. A cap of 0 disables the check.
+   */
+  private fun addFileCapped(
+    zos: ZipOutputStream,
+    entryName: String,
+    file: File,
+    counting: CountingOutputStream,
+    maxBytes: Long,
+  ): Boolean {
+    if (maxBytes > 0 && counting.bytesWritten + file.length() > maxBytes) {
+      return false
+    }
+    addFile(zos, entryName, file)
+    return true
+  }
+
+  /**
+   * Minimal byte-counting [java.io.OutputStream] wrapper. Tracks total bytes written to
+   * the underlying stream so the exporter can decide when to stop appending entries.
+   */
+  private class CountingOutputStream(
+    private val delegate: java.io.OutputStream,
+  ) : java.io.OutputStream() {
+    var bytesWritten: Long = 0L
+      private set
+
+    override fun write(b: Int) {
+      delegate.write(b)
+      bytesWritten++
+    }
+
+    override fun write(b: ByteArray, off: Int, len: Int) {
+      delegate.write(b, off, len)
+      bytesWritten += len
+    }
+
+    override fun flush() = delegate.flush()
+    override fun close() = delegate.close()
   }
 
   private fun writeEntry(zos: ZipOutputStream, name: String, bytes: ByteArray) {

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsSchedulePolicy.kt
@@ -34,6 +34,17 @@ data class DiagnosticsSchedulePolicy(
   val remoteTriggerCooldownMs: Long = 3_600_000L,
   val autoUploadEnabled: Boolean = false,
   val includeExtendedPosture: Boolean = true,
+  /**
+   * Maximum size in bytes for the diagnostics ZIP produced by
+   * [com.sarastarquant.kioskops.sdk.KioskOpsSdk.exportDiagnostics]. On a deep backlog the
+   * export can otherwise reach hundreds of MiB, stalling the host-supplied uploader or
+   * running the device out of memory. When the cap is exceeded, later telemetry/audit/log
+   * entries are omitted and a `truncation.txt` marker entry is added to the ZIP.
+   *
+   * Default 50 MiB. Set to 0 to disable the cap.
+   * @since 1.2.0
+   */
+  val maxExportBytes: Long = 50L * 1024L * 1024L,
 ) {
   /**
    * Schedule type for diagnostics collection.
@@ -50,6 +61,7 @@ data class DiagnosticsSchedulePolicy(
     require(scheduleDayOfWeek in 1..7) { "scheduleDayOfWeek must be 1-7" }
     require(maxRemoteTriggersPerDay >= 0) { "maxRemoteTriggersPerDay must be non-negative" }
     require(remoteTriggerCooldownMs >= 0) { "remoteTriggerCooldownMs must be non-negative" }
+    require(maxExportBytes >= 0) { "maxExportBytes must be non-negative" }
   }
 
   companion object {

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/QueueRepository.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/QueueRepository.kt
@@ -12,6 +12,12 @@ import com.sarastarquant.kioskops.sdk.util.Idempotency
 import com.sarastarquant.kioskops.sdk.util.Ids
 import com.sarastarquant.kioskops.sdk.util.InstallSecret
 
+// Caps arbitrary server-returned error strings written into queue_events.lastError.
+// Server error bodies can be lorem-ipsum long or carry accidental PII; 256 characters
+// is enough for meaningful diagnostic context without letting the queue DB bloat.
+private const val MAX_LAST_ERROR_CHARS = 256
+private const val TRUNCATED_MARKER = "...[truncated]"
+
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 class QueueRepository(
   context: Context,
@@ -206,7 +212,14 @@ class QueueRepository(
   }
 
   suspend fun markFailed(id: String, err: String, nextAttemptAtMs: Long, permanentFailure: Int, quarantineReason: String? = null) =
-    dao.markFailed(id, err, quarantineReason, nextAttemptAtMs, permanentFailure, System.currentTimeMillis())
+    dao.markFailed(
+      id,
+      capErrorMessage(err),
+      quarantineReason?.let { capErrorMessage(it) },
+      nextAttemptAtMs,
+      permanentFailure,
+      System.currentTimeMillis(),
+    )
 
   /**
    * Record a batch-level failure for an event without incrementing its attempts counter.
@@ -214,7 +227,12 @@ class QueueRepository(
    * @since 1.2.0
    */
   suspend fun markBatchFailureNoAttemptBump(id: String, err: String, nextAttemptAtMs: Long) =
-    dao.markBatchFailureNoAttemptBump(id, err, nextAttemptAtMs, System.currentTimeMillis())
+    dao.markBatchFailureNoAttemptBump(id, capErrorMessage(err), nextAttemptAtMs, System.currentTimeMillis())
+
+  private fun capErrorMessage(msg: String): String {
+    return if (msg.length <= MAX_LAST_ERROR_CHARS) msg
+    else msg.substring(0, MAX_LAST_ERROR_CHARS - TRUNCATED_MARKER.length) + TRUNCATED_MARKER
+  }
 
   suspend fun markSent(id: String) = dao.markSent(id, System.currentTimeMillis())
 

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsExporterTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/diagnostics/DiagnosticsExporterTest.kt
@@ -138,4 +138,76 @@ class DiagnosticsExporterTest {
     assertThat(content).contains("test-policy-hash")
     zip.close()
   }
+
+  @Test
+  fun `export cap skips oversized entries and writes a truncation marker`() = runTest {
+    // Stage a large telemetry file so the exporter is forced to choose whether to include it.
+    val telemetryDir = java.io.File(ctx.filesDir, "kioskops_telemetry").apply { mkdirs() }
+    java.io.File(telemetryDir, "bulk.log").writeBytes(ByteArray(2048) { 'a'.code.toByte() })
+
+    val cfg = KioskOpsConfig(
+      baseUrl = "https://example.invalid",
+      locationId = "test-loc",
+      kioskEnabled = true,
+      securityPolicy = SecurityPolicy.maximalistDefaults().copy(
+        encryptQueuePayloads = false,
+        encryptTelemetryAtRest = false,
+        encryptExportedLogs = false,
+      ),
+      retentionPolicy = RetentionPolicy.maximalistDefaults(),
+      telemetryPolicy = TelemetryPolicy.maximalistDefaults(),
+      // Tiny cap: manifest + health + quarantined barely fit; bulk.log cannot.
+      diagnosticsSchedulePolicy = DiagnosticsSchedulePolicy.disabledDefaults().copy(
+        maxExportBytes = 1024L,
+      ),
+    )
+
+    val logs = RingLog(ctx)
+    val logExporter = LogExporter(ctx, logs, NoopCryptoProvider)
+    val telemetry = EncryptedTelemetryStore(
+      context = ctx,
+      policyProvider = { cfg.telemetryPolicy },
+      retentionProvider = { cfg.retentionPolicy },
+      clock = clock,
+      crypto = NoopCryptoProvider,
+    )
+    val audit = AuditTrail(
+      context = ctx,
+      retentionProvider = { cfg.retentionPolicy },
+      clock = clock,
+      crypto = NoopCryptoProvider,
+    )
+    val posture = DevicePosture(
+      isDeviceOwner = false,
+      isLockTaskPermitted = false,
+      androidSdkInt = 33,
+      deviceModel = "TestDevice",
+      manufacturer = "Robolectric",
+      securityPatch = "2026-01-01",
+    )
+    val cappedExporter = DiagnosticsExporter(
+      context = ctx,
+      cfgProvider = { cfg },
+      logs = logs,
+      logExporter = logExporter,
+      telemetry = telemetry,
+      audit = audit,
+      clock = clock,
+      sdkVersion = "0.7.0-test",
+      queueDepthProvider = { 0L },
+      quarantinedSummaryProvider = { emptyList() },
+      postureProvider = { posture },
+      policyHashProvider = { "test-policy-hash" },
+    )
+
+    val file = cappedExporter.export()
+    val zip = ZipFile(file)
+    val entries = zip.entries().toList().map { it.name }
+
+    assertThat(entries).contains("manifest.json")
+    assertThat(entries).contains("truncation.txt")
+    val marker = zip.getInputStream(zip.getEntry("truncation.txt")).bufferedReader().readText()
+    assertThat(marker).contains("maxExportBytes=1024")
+    zip.close()
+  }
 }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/queue/QueueDaoTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/queue/QueueDaoTest.kt
@@ -243,6 +243,34 @@ class QueueDaoTest {
   }
 
   @Test
+  fun `repository caps lastError length on markFailed`() = runTest {
+    val ctx = ApplicationProvider.getApplicationContext<Context>()
+    val repo = com.sarastarquant.kioskops.sdk.queue.QueueRepository(
+      ctx,
+      com.sarastarquant.kioskops.sdk.logging.RingLog(ctx),
+      com.sarastarquant.kioskops.sdk.crypto.NoopCryptoProvider,
+    )
+    ctx.deleteDatabase("kiosk_ops_queue.db")
+    val cfg = com.sarastarquant.kioskops.sdk.KioskOpsConfig(
+      baseUrl = "https://example.invalid/",
+      locationId = "LOC-1",
+      kioskEnabled = false,
+      securityPolicy = com.sarastarquant.kioskops.sdk.compliance.SecurityPolicy.maximalistDefaults()
+        .copy(encryptQueuePayloads = false),
+    )
+    val res = repo.enqueue("T", "{\"x\":1}", cfg)
+    val id = (res as com.sarastarquant.kioskops.sdk.queue.EnqueueResult.Accepted).id
+
+    val huge = "x".repeat(5000)
+    repo.markFailed(id, huge, nextAttemptAtMs = 0L, permanentFailure = 0)
+
+    val stored = repo.nextBatch(nowMs = 1L, limit = 1).first()
+    assertThat(stored.lastError).isNotNull()
+    assertThat(stored.lastError!!.length).isAtMost(256)
+    assertThat(stored.lastError).endsWith("...[truncated]")
+  }
+
+  @Test
   fun `markBatchFailureNoAttemptBump preserves attempts counter`() = runTest {
     dao.insert(entity())
     // Bump attempts once via a real per-event failure so we can observe the counter later.


### PR DESCRIPTION
## Summary

Two defensive caps against untrusted-or-unbounded writes into SDK persistent state. Both are low-risk, narrowly scoped, and close gaps that only matter under long-tail production conditions (misbehaving server, deep backlog).

## `lastError` length cap

`QueueRepository.markFailed` and `markBatchFailureNoAttemptBump` now truncate the error string to 256 characters before handing it to the DAO. Server error bodies`SyncEngine` passes `res.message` or `ack.error` directly are arbitrary server-controlled strings. A misbehaving or malicious server can return lorem-ipsum kilobytes, or inadvertently echo PII scraped from the request, and those strings land in `queue_events.lastError`, then propagate into the audit trail and diagnostics exports.

- 256 chars is enough for meaningful diagnostic context without letting the queue DB bloat under sustained failure loops.
- Truncation uses a sentinel suffix `...[truncated]` so the truncation is observable in diagnostics.
- Applies both to the per-event `markFailed` path and the batch-transient no-attempt-bump path added in v1.2.

## Diagnostics export size cap

`DiagnosticsExporter` now wraps its underlying `OutputStream` with a byte-counting stream and checks remaining budget before appending each logs/telemetry/audit entry. When the cap would be exceeded, the entry is skipped and a `truncation.txt` marker is written listing the omitted paths.

- Critical small entries (`manifest.json`, `health_snapshot.json`, `queue/quarantined_summaries.json`) are always included so the ZIP remains diagnostically useful.
- Without the cap, a device carrying a deep queue backlog and months of telemetry can produce a multi-GB export that stalls the host uploader or OOMs the app. 50 MiB default covers typical investigative needs.
- New configuration knob: `DiagnosticsSchedulePolicy.maxExportBytes` (default 50 MiB, 0 to disable).

## API compatibility

`DiagnosticsSchedulePolicy` data class constructor gains `maxExportBytes` as the 10th parameter. Callers using named arguments are unaffected; callers using positional arguments to the 9-arg constructor will need to add the new parameter or migrate to named args. Noted in the CHANGELOG for v1.2.0.

No other public API changes. `QueueRepository` constants are file-private. Baseline regenerated.

## Tests

- `QueueDaoTest` adds a repository-level test that passes a 5000-char error and asserts the stored `lastError` is at most 256 chars and ends with `...[truncated]`.
- `DiagnosticsExporterTest` adds a size-cap truncation test that stages a large telemetry file, sets `maxExportBytes=1024`, and asserts the ZIP contains `truncation.txt` listing the skipped entry while preserving `manifest.json` / `health_snapshot.json`.

## Local verification

`./gradlew :kiosk-ops-sdk:testDebugUnitTest :kiosk-ops-sdk:apiCheck detekt :sample-app:assembleDebug` -> all green.
