### PR TITLE
Publish Dokka API reference to GitHub Pages

### DIFF
--- a/.github/workflows/dokka-pages.yml
+++ b/.github/workflows/dokka-pages.yml
@@ -1,0 +1,61 @@
+name: Publish Dokka to GitHub Pages
+
+# Rebuilds the Dokka HTML site on every push to main and on release tags, then publishes
+# it to GitHub Pages for https://sara-star-quant.github.io/KioskOps-SDK-Android-Enterprise/.
+#
+# Kept separate from build.yml so the main build never blocks on Pages deployment and so
+# a Pages rollback is a single-branch revert.
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*.*.*" ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v5.0.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v5.0.0
+
+      - name: Generate Dokka HTML
+        run: ./gradlew :kiosk-ops-sdk:dokkaGeneratePublicationHtml --no-daemon
+
+      - name: Prepare site root
+        run: |
+          mkdir -p "$SITE_DIR"
+          cp -r kiosk-ops-sdk/build/dokka/html/. "$SITE_DIR/"
+        env:
+          SITE_DIR: ${{ runner.temp }}/site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v4.0.0
+        with:
+          path: ${{ runner.temp }}/site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@
 [![API](https://img.shields.io/badge/API-33%2B-brightgreen.svg)](https://developer.android.com/about/versions/13)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.1-purple.svg)](https://kotlinlang.org/)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/Docs-Dokka-brightgreen.svg)](https://sara-star-quant.github.io/KioskOps-SDK-Android-Enterprise/)
 
 An **enterprise-grade Android SDK** for **offline-first operational events**, **local diagnostics**, and **fleet-friendly observability**. Designed for kiosk, retail, logistics, and field service deployments with **Samsung Knox / Android Enterprise** integration.
+
+API reference: [sara-star-quant.github.io/KioskOps-SDK-Android-Enterprise](https://sara-star-quant.github.io/KioskOps-SDK-Android-Enterprise/) (auto-published from `main` and release tags).
 
 > **Disclaimer:** This SDK provides security controls and references regulatory frameworks
 > (NIST 800-53, FedRAMP, GDPR, ISO 27001) as engineering aids only. It is not legal,


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dokka-pages.yml`: on every push to `main` or release tag, the workflow generates the Dokka HTML publication and deploys it to `https://sara-star-quant.github.io/KioskOps-SDK-Android-Enterprise/` via GitHub Pages.

Closes the v1.2.0 ROADMAP item "API reference documentation (Dokka) published to GitHub Pages".

## Design choices

- **Reuses the existing `dokkaGeneratePublicationHtml` task** that is already wired up for the Maven Central javadoc JAR. The Pages site therefore stays in lock-step with the `javadoc` classifier published on every release, so a consumer reading the published POM sees the same API surface as the site.
- **Separate workflow file** rather than an extra job on `build.yml`. A Pages deployment issue never blocks the main build; a rollback is a single-workflow revert.
- **GitHub Pages with `actions/deploy-pages`** (artifact-based), not the legacy `gh-pages` branch approach. Cleaner for monorepo settings and aligns with GitHub's current recommendation.
- **Action SHAs pinned** per repo convention. `v*` tag shortcuts would be a supply-chain weak spot for a security-focused project.

## Triggers

| Event | Reason |
|---|---|
| `push` to `main` | Keep docs fresh against the mainline surface. |
| `push` to `v*.*.*` tag | Release docs land under the same URL. |
| `workflow_dispatch` | Manual rebuild for content-only doc fixes. |

## Permissions

Job-scoped to `contents: read` + `pages: write` + `id-token: write`. Default repo `GITHUB_TOKEN` scope stays `contents: read` per `permissions:` block at the top of the workflow.

No `github.event.*` user-controlled inputs are interpolated into `run:` commands. The one shell script (`Prepare site root`) uses `env.SITE_DIR` set from `runner.temp`, which is runner-controlled.

## README

Badge + one-line pointer to the site URL added at the top of the README.

## No code changes

Pure workflow + README addition. No tests, no SDK surface change. Baseline unchanged.

## Local verification

`./gradlew :kiosk-ops-sdk:dokkaGeneratePublicationHtml` produces HTML under `kiosk-ops-sdk/build/dokka/html/` on a clean checkout; the workflow's upload step just takes that output.
