### PR TITLE
Add CII Passing security documentation

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -21,6 +21,14 @@ Please upgrade to the latest release.
 
 We take security vulnerabilities seriously. If you discover a security issue, please report it responsibly.
 
+See [docs/VULNERABILITY_RESPONSE.md](../docs/VULNERABILITY_RESPONSE.md) for the full SLA,
+severity bands, coordinated-disclosure expectations, and what ships with a security
+release. The short version is below.
+
+See [docs/VULNERABILITY_RESPONSE.md](../docs/VULNERABILITY_RESPONSE.md) for the full SLA,
+severity bands, coordinated-disclosure expectations, and what ships with a security
+release. The short version is below.
+
 ### How to Report
 
 **Please do NOT report security vulnerabilities through public GitHub issues.**

--- a/docs/HARDENING.md
+++ b/docs/HARDENING.md
@@ -1,0 +1,173 @@
+# Production Hardening Checklist
+
+A walk-through of what to enable when taking KioskOps SDK from a pilot to a fleet in
+production. Each item states **why** (not just what), so reviewers evaluating against
+FedRAMP / NIST 800-171 / CJIS / ASD Essential Eight / GDPR can justify the choices.
+
+> Complements [SECURE_DESIGN](SECURE_DESIGN.md) (principles) and
+> [SECURITY_COMPLIANCE](SECURITY_COMPLIANCE.md) (framework crosswalk). This page is
+> operational: what to flip on.
+
+## 1. Pick the right preset
+
+Starting point matters. The SDK ships four high-security preset factories:
+
+| Preset | Use case | Defaults it sets |
+|---|---|---|
+| `fedRampDefaults` | NIST 800-53 / FedRAMP Moderate aligned deployments | strict validation + PII reject + field encryption + signed audit + 365d retention |
+| `cuiDefaults` | NIST 800-171 / CUI / DoD contractors | adds SQLCipher + data-rights authorization required + CONFIDENTIAL default classification |
+| `cjisDefaults` | Law-enforcement kiosks | same as CUI + CJIS section 5 alignment |
+| `asdEssentialEightDefaults` | Australian government | strict validation + PII redact + field encryption + signed audit |
+
+`gdprDefaults` is a lighter preset (redact instead of reject) for commercial non-federal
+workloads.
+
+## 2. Configure transport security
+
+Every high-security preset logs an ERROR when used with an HTTPS `baseUrl` and no
+`TransportSecurityPolicy.certificatePins` or `certificateTransparencyEnabled`. The CA
+trust store alone is not enough for these regimes. Pin the host against the specific
+certificate(s) you operate:
+
+```kotlin
+val cfg = KioskOpsConfig.fedRampDefaults(
+    baseUrl = "https://api.your-company.example",
+    locationId = "STORE-001",
+).copy(
+    transportSecurityPolicy = TransportSecurityPolicy(
+        certificatePins = listOf(
+            CertificatePin(
+                hostname = "api.your-company.example",
+                sha256Pins = listOf(
+                    "sha256/AAAA...", // primary leaf or intermediate
+                    "sha256/BBBB...", // backup (critical for rotation)
+                ),
+            ),
+        ),
+        certificateTransparencyEnabled = true,
+    ),
+)
+```
+
+Plan pin rotations with an overlap window where both old and new pins are valid.
+Rotating without overlap will quarantine your fleet.
+
+## 3. Enable database-at-rest encryption
+
+For CUI/CJIS you also get this via the preset, but you can enable it anywhere:
+
+```kotlin
+databaseEncryptionPolicy = DatabaseEncryptionPolicy.enabledDefaults()
+```
+
+Requires `net.zetetic:sqlcipher-android` on the classpath. The SQLCipher passphrase is
+32 random bytes wrapped with an Android Keystore AES-GCM key that never leaves
+TEE/StrongBox.
+
+## 4. Gate data-rights operations
+
+Data export, deletion, and wipe can exfiltrate an entire user's history or erase it.
+On shared-kiosk devices, require explicit authorization:
+
+```kotlin
+KioskOpsSdk.get().setDataRightsAuthorizer { request ->
+    if (myHostAppAuthenticatedUser() == request.subjectUserId) {
+        AuthorizationDecision.Authorized
+    } else {
+        AuthorizationDecision.Unauthorized("user_not_signed_in")
+    }
+}
+```
+
+The `cuiDefaults` and `cjisDefaults` presets set `requireDataRightsAuthorization = true`
+by default. All decisions are audit-logged.
+
+## 5. Enable signed audit and chain verification
+
+```kotlin
+securityPolicy = SecurityPolicy.highSecurityDefaults().copy(
+    signAuditEntries = true,
+)
+```
+
+Periodically call `verifyAuditIntegrity(fromTs, toTs)` and surface the result to your
+SOC. `ChainVerificationResult.Broken` is a tamper indicator.
+
+## 6. Size the queue and retention for your fleet
+
+Default `QueueLimits` caps at 100k events / 10 MB. If your workload drives higher
+throughput, raise explicitly; don't let the queue silently drop events:
+
+```kotlin
+queueLimits = QueueLimits(
+    maxActiveEvents = 500_000,
+    maxActiveBytes = 50L * 1024L * 1024L,
+    overflowStrategy = OverflowStrategy.DROP_OLDEST,
+)
+retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
+    retainSentEventsDays = 14,
+    retainFailedEventsDays = 30,
+    retainAuditDays = 365,
+)
+```
+
+For compliance regimes that mandate long audit retention (FedRAMP AU-11 requires one
+year), `retainAuditDays` must be set to at least that value; the presets already do.
+
+## 7. Diagnostics export hygiene
+
+- Set `DiagnosticsSchedulePolicy.maxExportBytes` explicitly. 50 MiB default; raise only
+  if your upload path is known-resilient.
+- If you wire `DiagnosticsUploader`, make sure it runs on constrained networks
+  (honors the device's unmetered / battery-not-low state). The SDK schedules
+  `DiagnosticsSchedulerWorker` respecting those constraints already.
+
+## 8. Managed configuration (MDM)
+
+Push `KioskOpsConfig` via the device's managed-config path rather than hard-coding in
+the APK:
+
+```kotlin
+val cfg = ManagedConfigReader.read(context, defaults)
+KioskOpsSdk.init(context, configProvider = { cfg })
+```
+
+Rotate `TransportSecurityPolicy.certificatePins` through the same channel; no app
+update required. Deployments under `RemoteConfigPolicy.enterpriseDefaults()` require
+signed config bundles so a compromised managed-config push cannot install a weaker
+policy.
+
+## 9. `pilotDefaults` never in production
+
+`RemoteConfigPolicy.pilotDefaults` is `@RequiresOptIn(PilotConfig)` since 1.2.0. If your
+production build requires an `@OptIn(PilotConfig::class)` marker, that's a bug; remove
+it and switch to `enterpriseDefaults()`. Pilot defaults disable signature verification
+and accept any version, which is the wrong posture for a fleet.
+
+## 10. Observability
+
+- Register a `KioskOpsErrorListener` that routes `KioskOpsError.*` to your error-tracking
+  backend (Sentry, Datadog, Firebase Crashlytics, etc.). Listener-side exceptions are
+  swallowed defensively but logged at `warn` so your own bugs don't go unnoticed.
+- Collect the `queueDepthFlow` Room-reactive stream into your UI or dashboard so
+  operators can see backlog drift early.
+- Periodically call `getAuditStatistics()` on the host side to detect silent failure
+  patterns (e.g., no `heartbeat` entries in the last 24h indicates the worker is dead).
+
+## 11. Out-of-band disaster drills
+
+- Document that `DataRightsManager.wipeAllSdkData()` fully clears SDK state. Exercise
+  it in a staging environment before trusting it in production.
+- Simulate a pin rotation in staging: push a config bundle with the new pin, monitor
+  `certificate_pin_failure` audit entries drain to zero.
+- Simulate a database corruption on a test device (delete a few database pages) and
+  verify `KioskOpsError.StorageError` reaches your error listener and the SDK
+  automatically recovers.
+
+## What this doc is not
+
+A replacement for your own threat model, penetration test, or regulatory assessment.
+It's an opinionated checklist reflecting the SDK's design constraints. Your fleet's
+threat model may add requirements this list doesn't mention (region-specific data
+residency, hardware attestation quorum, physical tamper response). Treat this as a
+floor, not a ceiling.

--- a/docs/SECURE_DESIGN.md
+++ b/docs/SECURE_DESIGN.md
@@ -1,0 +1,104 @@
+# Secure Design Principles
+
+This document captures the design principles the SDK is built to. It is intended for
+integrators performing a security review and for reviewers evaluating this project
+against the [OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/) Silver
+criterion set. It is not a certification. See [LEGAL disclaimer](../README.md#disclaimer).
+
+## Core principles
+
+### 1. Secure-by-default
+
+Public APIs default to the most conservative behavior. Enabling a risky option is always
+an explicit call:
+
+- Network sync is **off by default** (`SyncPolicy.disabledDefaults()`). A misconfigured
+  host app cannot silently transfer events off-device.
+- `PiiPolicy.maximalistDefaults()` rejects events containing likely PII. The host must
+  explicitly switch to `redactDefaults()` or `disabledDefaults()` to relax.
+- `SecurityPolicy.encryptQueuePayloads` is on by default. Payloads never sit in the
+  queue database in the clear unless the host opts out.
+- `DatabaseEncryptionPolicy.enabled` controls SQLCipher; when on, the database passphrase
+  is wrapped by an Android Keystore AES-GCM key that never leaves TEE/StrongBox.
+
+### 2. Explicit data-transfer boundaries
+
+The SDK never uploads data on its own. The only code path that crosses the host-app
+boundary is when `SyncPolicy.enabled == true` **and** a reachable `baseUrl` is configured
+**and** an `AuthProvider` is installed (or a custom `OkHttpClient` is provided). A host
+can additionally reset all SDK state via `dataRights.wipeAllSdkData()` or delete per-user
+data via `dataRights.deleteUserData(userId)`.
+
+Diagnostics export is explicit per invocation; upload is host-controlled via the
+`DiagnosticsUploader` interface. The SDK never calls back to a network endpoint the host
+did not configure.
+
+### 3. Fail loud, not silent
+
+Cryptographic, storage, and transport failures surface rather than silently degrade:
+
+- `FieldLevelEncryptor` throws `FieldEncryptionException` on failure; the event pipeline
+  rejects the event with `EnqueueResult.Rejected.FieldEncryptionFailed`.
+- `MtlsClientBuilder` throws `MtlsConfigurationException` on any misconfiguration; it
+  does not downgrade to unauthenticated TLS.
+- `DatabaseCorruptionHandler` (wired into the Room open-helper factory) surfaces
+  corruption to `KioskOpsErrorListener` and lands an audit entry before Room's
+  default recreate runs.
+- `KioskOpsErrorListener` callbacks swallow `Throwable` defensively (the SDK never
+  crashes from a host listener) but log the swallowed exception at `warn` so host
+  teams can see the misbehavior in their logcat and diagnostics.
+
+### 4. Local-first observability
+
+Telemetry, audit, and the event queue live on-device only. Nothing ships off-device
+without host action. The queue and audit databases are encrypted at rest when the
+corresponding policy flag is on. The audit trail is tamper-evident: each entry is
+chained via SHA-256 and, when `SecurityPolicy.signAuditEntries` is on, signed with a
+Keystore-backed key attested by the device.
+
+### 5. Defense-in-depth for credentials and secrets
+
+- SQLCipher passphrase: wrapped with a Keystore AES-GCM key.
+- Per-install secret (`InstallSecret`, used for deterministic idempotency): wrapped the
+  same way since 1.2.0, and zeroed after use at the call site.
+- Random attestation challenges: 32 bytes of `SecureRandom`.
+- Deterministic key derivation: HKDF-SHA256 (RFC 5869); no PBKDF2-over-char-array
+  bridge since 1.2.0.
+- Certificate pinning: enforced during the TLS handshake by OkHttp's native
+  `CertificatePinner`, not as a post-response interceptor, so no request body leaks
+  against a rogue server.
+
+### 6. Minimum Android surface
+
+- `minSdk = 33` (Android 13). Keystore-backed cryptography, scoped storage, and the
+  modern intent model are assumed; older branches aren't maintained.
+- `compileSdk` tracks the latest stable platform.
+- No unbounded reflection, no `allowBackup = true` in the SDK manifest, no cleartext
+  HTTP targets in the SDK-built `OkHttpClient`.
+
+### 7. Reproducible builds and provenance
+
+Every release artifact is:
+
+- Signed by `sigstore/cosign-installer` with keyless signing.
+- Described by a CycloneDX SBOM uploaded as a release asset.
+- Verified against the `gradle-wrapper.jar` binary via `gradle-wrapper-validation` on
+  every push.
+- Produced by a GitHub Actions job whose SHAs are pinned in every workflow in this repo.
+
+## What the SDK does not claim
+
+The SDK ships engineering primitives that make it easier to hit compliance targets
+(FedRAMP, NIST 800-171, CJIS, ASD Essential Eight, GDPR). It is not an auditor and it
+cannot give you a certification. The regulatory-framework references in KDoc and in
+compliance preset names are engineering aids, not legal claims.
+
+Third-party assessments, penetration tests, and continuous-monitoring obligations
+remain the host organization's responsibility.
+
+## Related docs
+
+- [HARDENING](HARDENING.md) -- operational hardening checklist for production.
+- [VULNERABILITY_RESPONSE](VULNERABILITY_RESPONSE.md) -- disclosure and remediation SLA.
+- [SECURITY_COMPLIANCE](SECURITY_COMPLIANCE.md) -- feature-by-framework crosswalk.
+- [TROUBLESHOOTING](TROUBLESHOOTING.md) -- operator runbook for common symptoms.

--- a/docs/VULNERABILITY_RESPONSE.md
+++ b/docs/VULNERABILITY_RESPONSE.md
@@ -1,0 +1,108 @@
+# Vulnerability Response
+
+How KioskOps SDK receives, triages, and resolves security reports. This page is the
+authoritative commitment referenced from
+[`.github/SECURITY.md`](../.github/SECURITY.md) and from the OpenSSF Best Practices
+Passing / Silver badge application.
+
+Nothing here constitutes a warranty; see the repository's [LICENSE](../LICENSE) and
+[README disclaimer](../README.md#disclaimer).
+
+## Scope
+
+Reports covered by this process:
+
+- Code vulnerabilities in the `kiosk-ops-sdk` module.
+- Vulnerabilities in SDK-owned build tooling that ship in the published AAR
+  (transitive runtime dependencies).
+- Documentation guidance that would lead an integrator to an insecure configuration.
+
+Out of scope (report directly to the upstream project):
+
+- Vulnerabilities in third-party libraries the SDK depends on but does not wrap.
+- Issues in the sample app's business logic (the sample app is a demonstration, not a
+  supported component).
+- Feature requests dressed as CVEs.
+
+## Reporting channel
+
+Email **pzverkov@protonmail.com** with subject line beginning `[kiosk-ops-sdk SECURITY]`.
+Include:
+
+- Affected version(s) and git commit SHA if known.
+- Vulnerability class (per CWE if practical).
+- Step-by-step reproduction or PoC.
+- Impact assessment (who is affected, under what conditions).
+- Whether you plan to publicly disclose and on what timeline.
+
+Encrypted communication is welcome. A PGP key is available on request; send a plain
+introductory email first, we'll respond with the public key.
+
+## SLA commitments
+
+| Phase | Target | Start time |
+|---|---|---|
+| Acknowledgement | 48 hours | On receipt of the report |
+| Initial triage + CVSS draft | 7 calendar days | On acknowledgement |
+| Remediation plan + ETA | 14 calendar days | On triage completion |
+| Resolution | 90 days max, prioritized by severity | On remediation plan |
+| Advisory publication | Same day as fix release | On resolution |
+
+**Severity bands (CVSS 3.1 base score):**
+
+- Critical (9.0+): hotfix release targeted within 14 days of triage.
+- High (7.0-8.9): next scheduled minor release, ideally within 30 days.
+- Medium (4.0-6.9): next scheduled minor release within 90 days.
+- Low (< 4.0): rolled into regular maintenance.
+
+These are targets; the actual timeline may shift for complex vulnerabilities or when
+coordinated disclosure with upstream requires more time. We will communicate changes in
+advance.
+
+## Coordinated disclosure
+
+We prefer coordinated disclosure. If you intend to publish, share your planned
+disclosure date with the initial report. If a negotiated extension is needed, we'll
+request it before the end of the 90-day default window and explain why.
+
+We credit reporters in the published advisory unless the reporter asks to be kept
+anonymous.
+
+## What we ship with a security release
+
+For releases that address a CVE or a security defect even without a CVE, the release
+includes:
+
+- A [CHANGELOG](../CHANGELOG.md) entry with the affected range and CVE if assigned.
+- A [GitHub Security Advisory](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/security/advisories)
+  with affected-versions metadata so Dependabot flags downstream consumers.
+- A sigstore/cosign signature on the published AAR (via the release workflow).
+- CycloneDX SBOM updated to reflect any dependency pivots.
+
+## Reporter expectations
+
+Don't:
+
+- Test on production systems belonging to anyone but yourself.
+- Use social engineering or physical intrusion to obtain the vulnerability.
+- Publicly disclose before the coordinated date (if agreed) or before our 90 days
+  elapse (if not).
+- Access or modify data that isn't yours.
+
+Do:
+
+- Report in good faith. We will not pursue legal action against researchers who follow
+  this process.
+
+## Historical advisories
+
+Advisories for this project are published at:
+<https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/security/advisories>.
+
+## Related
+
+- [SECURE_DESIGN](SECURE_DESIGN.md) -- design principles the fixes are held to.
+- [HARDENING](HARDENING.md) -- what consumers can do to reduce their exposure window.
+- [SECURITY_COMPLIANCE](SECURITY_COMPLIANCE.md) -- feature-by-framework crosswalk.
+- [TROUBLESHOOTING](TROUBLESHOOTING.md) -- operator runbook for symptoms that may or
+  may not be security incidents.


### PR DESCRIPTION
## Summary

Three new documents under `docs/` plus a pointer from `.github/SECURITY.md`, fulfilling the CII Passing criteria for documented design, hardening guidance, and vulnerability response. No code or workflow changes.

**Note on the PR scope:** The audit plan's S3 item ("scheduled weekly fuzzing workflow on `main`") was already delivered by the existing `.github/workflows/fuzz.yml`, which runs `cron: '0 3 * * 0'` (Sundays at 3 AM UTC) in addition to push/PR triggers. No new workflow is needed. This PR therefore covers S4 only.

## Files

### `docs/SECURE_DESIGN.md`

Seven design principles the SDK is built to:

1. Secure-by-default (sync off, PII reject, queue encryption on)
2. Explicit data-transfer boundaries (no silent off-device transfer)
3. Fail loud, not silent (no silent crypto/transport degradation)
4. Local-first observability (telemetry/audit stay on device)
5. Defense-in-depth for credentials and secrets (Keystore wrapping, HKDF, handshake-time pinning, secret zeroing)
6. Minimum Android surface (minSdk 33, no backups in the SDK manifest)
7. Reproducible builds and provenance (cosign, SBOM, wrapper validation, SHA-pinned actions)

Intended as the reference for integrator security reviews and as the anchor for Silver-adjacent criteria that won't resolve until a second reviewer is onboarded.

### `docs/HARDENING.md`

Eleven-item production hardening checklist:

1. Pick the right preset (fedRamp / cui / cjis / asdEssentialEight / gdpr)
2. Configure transport security (pins + CT)
3. Enable database-at-rest encryption
4. Gate data-rights operations with `DataRightsAuthorizer`
5. Enable signed audit and chain verification
6. Size queue and retention for your fleet
7. Diagnostics export hygiene (`maxExportBytes`, uploader constraints)
8. MDM-driven config via `ManagedConfigReader`
9. `pilotDefaults` never in production (opt-in marker enforces this)
10. Observability (error listener routing, queueDepthFlow, audit stats)
11. Out-of-band disaster drills (wipe, pin rotation, corruption simulation)

Each item states *why*, not just *what*, so a compliance reviewer can justify the choice. Explicit framing that this is a floor, not a ceiling.

### `docs/VULNERABILITY_RESPONSE.md`

Authoritative response SLA:

| Phase | Target |
|---|---|
| Acknowledgement | 48 hours |
| Initial triage + CVSS draft | 7 days |
| Remediation plan + ETA | 14 days |
| Resolution | 90 days max, prioritized by severity |
| Advisory publication | Same day as fix release |

Severity bands (Critical/High/Medium/Low) map to CVSS 3.1 base scores; band drives remediation pace. Coordinated-disclosure expectations. What a security release ships with (CHANGELOG entry, GitHub Security Advisory, cosign signature, updated SBOM).

### `.github/SECURITY.md`

Adds a single-line pointer to the new response doc. The existing short summary stays in place so the GitHub-rendered "Security" tab still displays the essentials.

## API compatibility

Documentation only. No code, no workflow, no test changes.

## CII Passing status after this PR

| Criterion | Before | After |
|---|---|---|
| `documentation_roadmap` | implicit in ROADMAP.md | no change |
| `documentation_security` | partial (`SECURITY.md` only) | full (SECURE_DESIGN + HARDENING + SECURITY) |
| `vulnerability_report_process` | 48h SLA only | full SLA table, severity bands, what-ships |
| `documentation_quick_start` | README | no change |
| `vulnerabilities_fixed_60_days` | already enforced by process | no change |

Silver-adjacent items still blocked on the single-reviewer constraint (`two_unassociated_reviewers_met`, `code_review_met`) are documented in v1.3 ROADMAP as a separate item for when a second maintainer onboards.

## Local verification

Docs only; no build impact.
