### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,165 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-04-20
+
+Reliability and security hardening release. Closes the v1.0 audit follow-ups,
+adds the transport-layer integrity upgrade, tightens defaults for
+high-security presets, and completes the observability primitives integrators
+asked for. No breaking changes; one source-compat nuance on
+`DiagnosticsSchedulePolicy` positional constructors noted below.
+
+### Added
+
+- `QueueDao.reconcileStaleSending` and `KioskOpsSdk.init` call site that reset
+  queue rows stranded in `SENDING` for more than five minutes back to
+  `PENDING`. Events abandoned by a mid-sync crash no longer rot silently
+  until retention deletes them.
+- `QueueDao.markBatchFailureNoAttemptBump` and `QueueRepository`
+  equivalent. `SyncEngine` uses this path for batch-level transient and
+  permanent failures so a long outage no longer marches the entire backlog
+  to `maxAttemptsPerEvent` and quarantines it.
+- `CorruptionHandlingOpenHelperFactory` wraps the Room open-helper factory
+  (SQLCipher or framework default) so corruption surfaces via
+  `KioskOpsErrorListener.StorageError` and lands in the audit trail before
+  Room's default delete-and-recreate runs.
+- `SyncPolicy.connectTimeoutSeconds`, `readTimeoutSeconds`,
+  `writeTimeoutSeconds`, `callTimeoutSeconds` with fleet-safe defaults
+  (15/30/30/60). Previously the SDK-built `OkHttpClient` inherited OkHttp
+  defaults with no `callTimeout` at all, so a slow server could stall the
+  sync worker indefinitely.
+- `QueueDao.countNotSentFlow` and `QueueRepository.countActiveFlow`. These
+  back the new Room-reactive `KioskOpsSdk.queueDepthFlow()` and
+  `healthStatusFlow()` behavior.
+- `DiagnosticsSchedulePolicy.maxExportBytes` (default 50 MiB) caps the
+  diagnostics ZIP size. Oversized entries are omitted and a
+  `truncation.txt` marker is added to the ZIP.
+- `RemoteConfigPolicy.PilotConfig` nested annotation.
+  `RemoteConfigPolicy.pilotDefaults` is now `@RequiresOptIn(WARNING)` so
+  production call sites must acknowledge the lower-security posture.
+- `InstallSecret.zeroize(bytes)` helper for defense-in-depth zeroing of
+  caller-owned secrets after use.
+- New documentation in `docs/`:
+  - `TROUBLESHOOTING.md` operator runbook with nine symptom-diagnosis-fix
+    recipes.
+  - `SECURE_DESIGN.md` seven design principles the SDK is built to.
+  - `HARDENING.md` eleven-item production checklist with compliance
+    rationale per item.
+  - `VULNERABILITY_RESPONSE.md` SLA, severity bands, coordinated-disclosure
+    expectations.
+- GitHub Pages publishing of the Dokka API reference via
+  `.github/workflows/dokka-pages.yml`. The published site replays the same
+  Dokka HTML output used for the Maven Central javadoc JAR.
+
+### Changed
+
+- `SecureKeyDerivation.deriveDeterministic` now uses HKDF-SHA256 (RFC 5869)
+  instead of PBKDF2 over an `ISO-8859-1` char-array bridge. HKDF is the
+  correct primitive for reproducible derivation from high-entropy keying
+  material; the prior PBKDF2 path was lossy across JCE providers. Output
+  bytes differ; `deriveDeterministic` has no production callers yet, so
+  the change is behavior-safe.
+- `InstallSecret.getOrCreate` now wraps the per-install secret with an
+  Android Keystore AES-GCM key (parity with `DatabaseEncryptionProvider`).
+  Legacy unwrapped entries are migrated in place on first access. Callers
+  using the SDK's idempotency path are unaffected.
+- `FileSink.emit` is now guarded by a dedicated monitor. Prior
+  `AtomicInteger + ConcurrentLinkedDeque` racing drained the buffer to
+  empty on a single overflow event and could produce negative sizes under
+  concurrent emit.
+- `KioskOpsSdk.shutdown` flushes the final audit and telemetry record under
+  `NonCancellable` before cancelling `sdkJob`. Prior ordering cancelled
+  the scope first and the `sdk_shutdown` entry was silently dropped.
+- `applySchedulingFromConfig` now uses `ExistingPeriodicWorkPolicy.KEEP`
+  for both the heartbeat and event-sync periodic work. Prior `UPDATE`
+  reset WorkManager's exponential-backoff counter on every SDK init,
+  which caused a crash-loop app to retry immediately instead of backing
+  off.
+- `RemoteConfigManager._configUpdates` uses
+  `BufferOverflow.DROP_OLDEST`. Prior default-SUSPEND could back-pressure
+  the applier's critical path from a slow collector.
+- `CertificatePinningInterceptor` usage replaced with OkHttp's native
+  `okhttp3.CertificatePinner` installed on the `OkHttpClient.Builder`.
+  Pin validation now runs inside the TLS handshake, so a rogue server
+  cannot receive a request body before the SDK rejects the connection.
+  The interceptor class is retained as `@Deprecated(WARNING)` for source
+  compatibility; removal targeted for 1.4.0.
+- `KioskOpsSdk.queueDepthFlow()` and `healthStatusFlow(intervalMs)` are
+  Room-reactive since this release. `queueDepthFlow` emits on DB change,
+  not on timer; `healthStatusFlow` combines DB change with the ticker so
+  non-reactive fields still refresh on schedule. The `intervalMs` parameter
+  on `queueDepthFlow` is retained for binary compatibility but ignored.
+- `QueueRepository.markFailed` and `markBatchFailureNoAttemptBump` truncate
+  the stored `lastError` at 256 characters with a `...[truncated]` marker,
+  bounding DB growth and accidental PII from misbehaving server error
+  bodies.
+- `DiagnosticsExporter` streams into a byte-counting `OutputStream` and
+  respects `DiagnosticsSchedulePolicy.maxExportBytes`.
+- `KioskOpsSdk.notifyError` now logs `warn` on listener-side exceptions
+  instead of silently swallowing, so a broken host-app error listener is
+  observable in logcat and diagnostics.
+- High-security preset factories (`fedRampDefaults`, `cuiDefaults`,
+  `cjisDefaults`, `asdEssentialEightDefaults`) log `android.util.Log.e`
+  when called with an HTTPS `baseUrl` but without certificate pins or
+  Certificate Transparency configured.
+- Toolchain bump: Kotlin 2.1.0 to 2.3.20, KSP 2.1.0-1.0.29 to 2.3.6,
+  kotlinx-serialization-json 1.8.0 to 1.11.0, androidx.room 2.7.1 to
+  2.8.4, androidx.lifecycle 2.9.0 to 2.10.0, androidx.work 2.11.1 to
+  2.11.2, androidx.test runner/rules/ext-junit bumped to 1.7.0/1.7.0/1.3.0,
+  binary-compatibility-validator 0.16.3 to 0.18.1, kover 0.9.1 to 0.9.8.
+- Build-classpath CVE pins: bouncycastle bcprov/bcpkix/bcutil/bcpg to 1.84,
+  plexus-utils to 4.0.3. Addresses GHSA-c3fc-8qff-9hwx, GHSA-wg6q-6289-32hp,
+  the bcpg Uncontrolled Resource Consumption advisory, and
+  GHSA-6fmv-xxpf-w3cw. None of these libraries ship in the SDK AAR; they
+  are transitive build-time dependencies.
+- GitHub org rename across all user-facing URLs (badges, POM metadata,
+  CHANGELOG release-tag links, CONTRIBUTING, ROADMAP, release workflow
+  summary). Coordinates on Maven Central and PGP-signed artifacts are
+  unchanged.
+
+### Deprecated
+
+- `CertificatePinningInterceptor`. Use OkHttp's native
+  `okhttp3.CertificatePinner`; the SDK wires this automatically when
+  `TransportSecurityPolicy.certificatePins` is non-empty.
+
+### Security
+
+- Closes the v1.0 audit follow-up to replace `deriveDeterministic`'s
+  ISO-8859-1 bridge with HKDF.
+- Closes the v1.0 audit follow-up to lock `FileSink`'s size counter.
+- Closes the v1.0 audit follow-up to move certificate pinning into the
+  TLS handshake.
+- Closes the v1.0 audit follow-up to warn on high-security presets with an
+  HTTPS endpoint but no pins or CT.
+- Closes the v1.0 audit follow-up to gate `pilotDefaults` behind opt-in.
+- Partial completion of the v1.0 audit follow-up for full SCT verification:
+  the native `CertificatePinner` lands now (bigger material win); full
+  SCT verification is deferred to v1.3.0 with three candidate
+  implementation paths documented in `ROADMAP.md` (self-implement
+  RFC 6962, re-vet appmattus once its Scorecard improves, or use
+  Conscrypt native CT).
+
+### Source compatibility
+
+- `DiagnosticsSchedulePolicy` data class constructor gains `maxExportBytes`
+  as the tenth parameter. Callers using named arguments are unaffected.
+  Callers using the nine-arg positional constructor must add the new
+  parameter or migrate to named arguments.
+
+### Binary compatibility
+
+- All other additions are purely additive; existing binary-compiled
+  consumers continue to resolve. `queueDepthFlow(Long)` retains its
+  signature so the `$default` synthetic is unchanged.
+
+### Known issues
+
+- `KioskOpsSdkIntegrationTest.heartbeat reason is reflected in healthCheck`
+  is intermittently flaky on CI; passes consistently locally. Tracked for
+  v1.3.0 to refactor the Robolectric test isolation. Does not affect SDK
+  behavior.
+
 ## [1.1.0] - 2026-04-18
 
 Security hardening release. Fixes several audit-surfaced confidentiality and
@@ -661,6 +820,9 @@ Initial release of KioskOps SDK for Android Enterprise.
 - Java 17+
 - Kotlin 2.1+
 
+[1.2.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v1.2.0
+[1.1.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v1.1.0
+[1.0.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v1.0.0
 [0.9.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.9.0
 [0.8.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.8.0
 [0.7.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v0.7.0

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.1.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.0")
 }
 ```
 
@@ -59,7 +59,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.1.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.0")
 }
 ```
 
@@ -75,7 +75,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.1.0")
+    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.2.0")
 }
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -338,67 +338,148 @@ paths in cryptographic and transport code.
 
 ---
 
-## v1.2.0 Distribution and Platform Expansion
+## v1.2.0 Reliability and Security Hardening [RELEASED]
 
-Focus: Coordinate multi-module version management, expand the Dependabot/
-toolchain surface, and prepare for cross-platform consumers.
+Focus: close the v1.0 audit follow-ups, finish reliability, make the SDK
+diagnosable. Re-scoped from the original "Distribution and Platform
+Expansion" plan after substantial reliability work accumulated on `main`;
+distribution/platform items moved to v1.3 / v1.4.
 
-### Stability
-- [ ] Long-term support (LTS) branch (cherry-pick security fixes to v1.1.x)
-- [ ] AGP 9.x evaluation - brings Bouncy Castle 1.84+ and closes the
-  remaining build-classpath CVE exposure
+### Reliability
+- [x] `DatabaseCorruptionHandler` wired into the Room open-helper factory
+  for both queue and audit databases; host sees `StorageError` and audit
+  trail records `database_corruption_detected` before Room recreates the
+  DB (PR #92)
+- [x] Reset `SENDING` rows stranded across a process crash on `init()`
+  with a 5-minute age gate (PR #92)
+- [x] Stop bumping per-event `attempts` on batch-level transient and
+  permanent failures so a long outage does not quarantine the backlog
+  (PR #92)
+- [x] Configurable OkHttp connect/read/write/call timeouts on `SyncPolicy`
+  so a slow server cannot stall the sync worker indefinitely (PR #93)
+- [x] `shutdown()` teardown record/emit run under `NonCancellable`
+  before the scope is cancelled (PR #93)
+- [x] WorkManager `ExistingPeriodicWorkPolicy.KEEP` for heartbeat + sync
+  periodic work (PR #93)
+- [x] `configUpdateFlow` backed by `BufferOverflow.DROP_OLDEST` (PR #93)
+- [x] Room-reactive `queueDepthFlow` and `healthStatusFlow` (PR #100)
+- [x] Cap `lastError` at 256 chars and diagnostics export ZIP at
+  `maxExportBytes` (default 50 MiB) with `truncation.txt` marker
+  (PR #99)
+- [x] Warn on swallowed `KioskOpsErrorListener` exceptions (PR #102)
 
-### Distribution
-- [ ] BOM artifact (`com.sarastarquant.kioskops:kioskops-bom`) for coordinated
-  version management
-- [ ] Gradle Version Catalog snippet for consumers
-
-### Platform Support
-- [ ] Kotlin Multiplatform (KMP) with iOS target
-- [ ] React Native bridge package
-- [ ] Flutter plugin
+### Audit follow-ups from the v1.0 review
+- [x] `SecureKeyDerivation.deriveDeterministic` migrated to HKDF-SHA256
+  (RFC 5869); PBKDF2-over-ISO-8859-1 bridge removed (PR #95)
+- [x] `FileSink` size counter guarded by a dedicated monitor (PR #95)
+- [x] Certificate pinning moved to OkHttp's native `CertificatePinner`
+  enforced inside the TLS handshake; hook preserved via
+  `EventListener` (PR #97)
+- [x] High-security presets (`fedRampDefaults`, `cuiDefaults`,
+  `cjisDefaults`, `asdEssentialEightDefaults`) log ERROR on HTTPS
+  `baseUrl` without pins or CT (PR #98)
+- [x] `RemoteConfigPolicy.pilotDefaults` marked
+  `@RequiresOptIn(WARNING)` via nested `@PilotConfig` annotation
+  (PR #98)
+- [x] `InstallSecret` wrapped with Keystore AES-GCM and zeroed after
+  use (PR #96)
 
 ### Documentation
-- [ ] API reference documentation (Dokka) published to GitHub Pages
-- [ ] Video tutorials and integration walkthroughs
-- [ ] Sample apps for common use cases (retail, logistics, field service)
+- [x] `docs/TROUBLESHOOTING.md` operator runbook (PR #101)
+- [x] `docs/SECURE_DESIGN.md`, `docs/HARDENING.md`,
+  `docs/VULNERABILITY_RESPONSE.md` for CII Passing application
+  (PR #104)
+- [x] API reference (Dokka) published to GitHub Pages (PR #103)
+- [x] `INTEGRATION.md` installation section corrected (PR #92)
 
 ### Security and assurance
-- [ ] Pre-filled SIG (Standardized Information Gathering) questionnaire template
-- [ ] Third-party penetration test (annual, recognized firm)
-- [ ] OpenSSF CII Best Practices badge (passing)
-- [ ] Scheduled weekly fuzzing workflow on `main`
-- [ ] Full SCT signature verification in `CertificateTransparencyValidator` --
-  **deferred to v1.3.0.** Initial investigation evaluated
-  `com.appmattus:certificatetransparency` 2.8.20: its library code has reasonable
-  signals (CodeQL SAST passing, license present), but OpenSSF Scorecard shows weak
-  release-pipeline trust (Maintained 0 in last 90 days, Token-Permissions 0,
-  Signed-Releases -1, no SECURITY.md). Importing into a security-focused SDK's
-  transport layer is inappropriate without stronger supply-chain signals. Candidate
-  paths for v1.3:
-  1. Self-implement RFC 6962 SCT parsing + signature verification (ECDSA P-256 / RSA
-     PKCS#1 v1.5) against a bundled IANA log list; ~500-800 lines of Kotlin plus a
-     log-list refresh strategy per release. Crypto primitives already present in
-     `Hkdf.kt` (HMAC-SHA256) and via `java.security`.
-  2. Re-vet `com.appmattus:certificatetransparency` once it publishes signed releases
-     and earns a Scorecard >=6.0; treat as a provisional dep and pin by hash.
-  3. Evaluate Conscrypt (BoringSSL-backed) which includes CT verification natively
-     on Android 10+; may remove the need for a Kotlin-side implementation for
-     `TransportSecurityPolicy.certificateTransparencyEnabled`.
+- [x] OpenSSF CII Best Practices badge application (Passing tier) --
+  documented scaffolding in this release; actual application filed
+  post-tag
+- [x] Scheduled weekly fuzzing workflow on `main` (already present in
+  `.github/workflows/fuzz.yml`)
 
-### Audit follow-ups (from 1.0.0 review, medium-severity)
-- [ ] Replace `SecureKeyDerivation.deriveDeterministic` ISO-8859-1 bridge with
-  HKDF-based byte construction and explicit length prefixing
-- [ ] Lock `FileSink` size counter under a dedicated mutex to prevent negative
-  values under concurrent emit
-- [ ] Switch `CertificatePinningInterceptor` to OkHttp's native
-  `certificatePinner`, so pin validation runs during the TLS handshake
-  before the request body is exchanged
-- [ ] High-security presets (`fedRampDefaults`, `cuiDefaults`, `cjisDefaults`)
-  validate that `baseUrl` HTTPS endpoints have pins configured or CT
-  enabled; log `ERROR` if not
-- [ ] `RemoteConfigPolicy.pilotDefaults` marked `@RequiresOptIn` /
-  `@Deprecated(WARNING)` to prevent accidental production use
+---
+
+## v1.3.0 Distribution
+
+Focus: fleet-friendly packaging and the cleanups the code surface has
+earned after 1.2. Deferred from the original v1.2 scope.
+
+### Distribution
+- [ ] BOM artifact (`com.sarastarquant.kioskops:kioskops-bom`) for
+  coordinated version management
+- [ ] Gradle Version Catalog snippet for consumers
+- [ ] LTS branch policy (cherry-pick security fixes to v1.1.x / v1.2.x)
+  with backport automation
+
+### Platform
+- [ ] AGP 9.x evaluation -- brings Bouncy Castle 1.84+ and closes the
+  remaining build-classpath CVE exposure root cause
+
+### Security
+- [ ] Full SCT signature verification per RFC 6962. Three candidate
+  implementation paths evaluated in 1.2; pick one:
+  1. Self-implement RFC 6962 SCT parsing + signature verification
+     (ECDSA P-256 / RSA PKCS#1 v1.5) against a bundled IANA log list;
+     ~500-800 lines of Kotlin plus a log-list refresh strategy per
+     release. Crypto primitives already present in `Hkdf.kt`
+     (HMAC-SHA256) and via `java.security`.
+  2. Re-vet `com.appmattus:certificatetransparency` once it publishes
+     signed releases and earns a Scorecard >=6.0; treat as a
+     provisional dep and pin by hash.
+  3. Evaluate Conscrypt (BoringSSL-backed) which includes CT
+     verification natively on Android 10+; may remove the need for a
+     Kotlin-side implementation for
+     `TransportSecurityPolicy.certificateTransparencyEnabled`.
+- [ ] Publish Kover coverage reports per release tag (CII Silver
+  `test_coverage_documented` criterion)
+- [ ] Fix intermittently flaky
+  `KioskOpsSdkIntegrationTest.heartbeat reason is reflected in healthCheck`
+  by refactoring Robolectric test isolation
+
+### Code quality
+- [ ] `cfg()` snapshot per public entry point (consistency with
+  `enqueueDetailed`)
+- [ ] Preset builder de-duplication
+  (`fedRampDefaults`/`cuiDefaults`/`cjisDefaults`/`asdEssentialEightDefaults`/`gdprDefaults`
+  share a `base(...)`)
+- [ ] `KioskOpsConfig.toString()` multi-line redacted pretty-print
+- [ ] Detekt baseline-rot CI guard
+
+### Documentation
+- [ ] `FEATURES.md` flattened capability matrix (Feature | Default |
+  Since | Link)
+- [ ] `ARCHITECTURE.md` subsystem diagram refresh with enqueue pipeline +
+  fleet/observability/compliance blocks
+- [ ] Legal disclaimer consolidated to `docs/LEGAL.md` (currently
+  copy-pasted across five files)
+
+### Compliance ops
+- [ ] Pre-filled SIG (Standardized Information Gathering) questionnaire
+  template
+
+---
+
+## v1.4.0 Cross-platform foundation
+
+Focus: second runtime, first platform.
+
+### Platform
+- [ ] Kotlin Multiplatform common module carved out of core
+- [ ] iOS target (Darwin) with Swift-friendly interop
+- [ ] React Native bridge package
+
+### Internal refactors
+- [ ] `KioskOpsSdk` namespace split (`fleet.*`, `audit.*`, `health.*`
+  accessors with flat-method deprecated forwards)
+- [ ] Java blocking-wrapper helper collapsing the six
+  `*Blocking` methods to one `future { }` delegate
+- [ ] Retention moved to a dedicated `RetentionWorker` (decouples from
+  heartbeat)
+
+### Observability
+- [ ] Event delivery confirmation callbacks (post-ack)
 
 ---
 
@@ -413,6 +494,7 @@ Features under consideration for post-1.0 releases:
 - [ ] Webhook delivery for real-time event streaming
 - [ ] Optional lightweight mode without Room (SQLite-only queue for resource-constrained devices)
 - [ ] Module split: `kioskops-core`, `kioskops-compliance`, `kioskops-analytics`
+- [ ] Flutter plugin (evaluate demand before committing)
 
 ### Observability & Debugging
 - [ ] Persistent crash-safe log export (survives process death)
@@ -425,6 +507,9 @@ Features under consideration for post-1.0 releases:
 - [ ] FedRAMP-compatible deployment patterns
 - [ ] HIPAA BAA-ready configuration presets
 - [ ] DPA (Data Processing Agreement) template for GDPR
+- [ ] Third-party penetration test. Not currently scheduled; pending
+  engagement funding. Tracked here rather than on a release milestone
+  so the plan stays honest about what we can actually commit to.
 
 ### Integrations
 - [ ] Firebase Analytics bridge

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ kotlin.code.style=official
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 # SDK Version
-VERSION_NAME=1.1.0
+VERSION_NAME=1.2.0

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
     applicationId = "com.sarastarquant.kioskops.sample"
     minSdk = 33
     targetSdk = 36
-    versionCode = 2
-    versionName = "1.1.0"
+    versionCode = 3
+    versionName = "1.2.0"
   }
 
   buildTypes {


### PR DESCRIPTION
## Summary

v1.2.0 release PR. Version bump, CHANGELOG, ROADMAP scope re-work, README install snippet updates.

## Scope check

This release collects the full v1.2.0 PR run landed in `main`:

| Area | PRs | Shipped |
|---|---|---|
| Reliability | #92, #93, #99, #100, #102 | Corruption handling, SENDING recovery, batch-transient fix, transport timeouts, shutdown ordering, WorkManager KEEP, Room-reactive flows, defensive caps, listener warning |
| v1.0 audit follow-ups | #95, #96, #97, #98 | HKDF, FileSink mutex, InstallSecret wrap + zero, native CertificatePinner, preset HTTPS audit, `pilotDefaults` `@RequiresOptIn` |
| Toolchain + build | #90, #91 | Kotlin 2.3, Room 2.8, androidx bumps, classpath CVE pins |
| Org rename | #94 | All GitHub URLs, POM metadata, badges |
| Documentation | #92, #101, #104, #103 | INTEGRATION fix, TROUBLESHOOTING runbook, CII Passing docs, Dokka on Pages |

Full per-PR accounting is in the CHANGELOG 1.2.0 entry.

## ROADMAP re-scope

| Before | After |
|---|---|
| v1.2.0 "Distribution and Platform Expansion" | v1.2.0 "Reliability and Security Hardening" [RELEASED] |
| v1.3.0 not defined | v1.3.0 "Distribution" (BOM, Gradle catalog, LTS, AGP 9.x, full SCT, CII Silver-adjacent, preset/toString/detekt cleanup, docs consolidation, SIG template) |
| v1.4.0 not defined | v1.4.0 "Cross-platform foundation" (KMP + iOS + RN, internal refactors) |
| Flutter on v1.2 list | Flutter in Future Considerations (pending demand) |
| Third-party pen test on v1.2 list | Future Considerations Regional & Compliance (no funding scheduled) |

## Release checklist

Pre-merge:

- [x] `VERSION_NAME=1.2.0` in `gradle.properties`
- [x] `sample-app/build.gradle.kts` `versionName = "1.2.0"`, `versionCode = 3`
- [x] README install snippets updated (Maven Central + JitPack)
- [x] CHANGELOG 1.2.0 entry with tag link
- [x] ROADMAP reflects actual v1.2 content and defines v1.3 / v1.4
- [x] `./gradlew :kiosk-ops-sdk:testDebugUnitTest :kiosk-ops-sdk:apiCheck detekt :sample-app:assembleDebug` green

Post-merge / tag:

- [ ] Tag `v1.2.0` -> release workflow publishes to Maven Central + GitHub Packages
- [ ] Apply for the OpenSSF CII Best Practices Passing badge referencing `docs/SECURE_DESIGN.md`, `docs/HARDENING.md`, `docs/VULNERABILITY_RESPONSE.md`
- [ ] **Enable GitHub Pages** at https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/settings/pages, source "GitHub Actions". The Dokka workflow from PR #103 currently 404s on the deploy step because Pages is not turned on. One-time toggle; next push to `main` or tag will succeed.
- [ ] Dismiss the four open Dependabot alerts (#27 plexus-utils, #28/#29 BC, #30 bcpg) with rationale "Risk tolerable: forced to fixed versions in root `build.gradle.kts` buildscript classpath; buildscript-only deps do not ship in the AAR"
- [ ] Trigger a fresh `submit-gradle` workflow on main so Dependabot's dependency-graph snapshot reflects the post-force versions

## Known issues shipped with this release

`KioskOpsSdkIntegrationTest.heartbeat reason is reflected in healthCheck` is intermittently flaky on CI (passes 5/5 locally; failure on a clean CI run seen during PR #104). Tracked in the v1.3.0 ROADMAP for a Robolectric test-isolation refactor. Does not affect SDK behavior; the `lastHeartbeatReason` assignment is the first line of `heartbeat()`, so the feature itself is sound.

## Source compatibility

`DiagnosticsSchedulePolicy` data class constructor gained `maxExportBytes` as the tenth parameter. Named-argument callers are unaffected; positional nine-arg callers need to add the new parameter or migrate to named arguments. Flagged in the CHANGELOG.

## Binary compatibility

No other breakages. `queueDepthFlow(Long)` signature preserved so the `$default` synthetic matches pre-1.2 compiled consumers. Additive only otherwise.

## Local verification

`./gradlew :kiosk-ops-sdk:testDebugUnitTest :kiosk-ops-sdk:apiCheck detekt :sample-app:assembleDebug` -> all green.
