### PR TITLE
Simplify formatting for public-facing files

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -414,7 +414,7 @@ earned after 1.2. Deferred from the original v1.2 scope.
   with backport automation
 
 ### Platform
-- [ ] AGP 9.x evaluation -- brings Bouncy Castle 1.84+ and closes the
+- [ ] AGP 9.x evaluation. Brings Bouncy Castle 1.84+ and closes the
   remaining build-classpath CVE exposure root cause
 
 ### Security

--- a/docs/SECURE_DESIGN.md
+++ b/docs/SECURE_DESIGN.md
@@ -98,7 +98,7 @@ remain the host organization's responsibility.
 
 ## Related docs
 
-- [HARDENING](HARDENING.md) -- operational hardening checklist for production.
-- [VULNERABILITY_RESPONSE](VULNERABILITY_RESPONSE.md) -- disclosure and remediation SLA.
-- [SECURITY_COMPLIANCE](SECURITY_COMPLIANCE.md) -- feature-by-framework crosswalk.
-- [TROUBLESHOOTING](TROUBLESHOOTING.md) -- operator runbook for common symptoms.
+- [HARDENING](HARDENING.md): operational hardening checklist for production.
+- [VULNERABILITY_RESPONSE](VULNERABILITY_RESPONSE.md): disclosure and remediation SLA.
+- [SECURITY_COMPLIANCE](SECURITY_COMPLIANCE.md): feature-by-framework crosswalk.
+- [TROUBLESHOOTING](TROUBLESHOOTING.md): operator runbook for common symptoms.

--- a/docs/VULNERABILITY_RESPONSE.md
+++ b/docs/VULNERABILITY_RESPONSE.md
@@ -101,8 +101,8 @@ Advisories for this project are published at:
 
 ## Related
 
-- [SECURE_DESIGN](SECURE_DESIGN.md) -- design principles the fixes are held to.
-- [HARDENING](HARDENING.md) -- what consumers can do to reduce their exposure window.
-- [SECURITY_COMPLIANCE](SECURITY_COMPLIANCE.md) -- feature-by-framework crosswalk.
-- [TROUBLESHOOTING](TROUBLESHOOTING.md) -- operator runbook for symptoms that may or
+- [SECURE_DESIGN](SECURE_DESIGN.md): design principles the fixes are held to.
+- [HARDENING](HARDENING.md): what consumers can do to reduce their exposure window.
+- [SECURITY_COMPLIANCE](SECURITY_COMPLIANCE.md): feature-by-framework crosswalk.
+- [TROUBLESHOOTING](TROUBLESHOOTING.md): operator runbook for symptoms that may or
   may not be security incidents.

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/FieldLevelEncryptor.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/FieldLevelEncryptor.kt
@@ -14,7 +14,7 @@ import java.util.Base64
 
 /**
  * Thrown when field-level encryption or decryption fails. Callers MUST NOT forward
- * the original plaintext when this is raised — doing so defeats the purpose of
+ * the original plaintext when this is raised; doing so defeats the purpose of
  * field-level encryption. Instead, reject the event or surface the failure to an
  * error listener.
  *

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/VersionedCryptoProvider.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/VersionedCryptoProvider.kt
@@ -269,7 +269,7 @@ class VersionedCryptoProvider(
 
   private fun deleteKeyVersion(version: Int) {
     // Delete from Keystore. If it fails, retain the metadata so a future
-    // cleanup cycle can retry — removing the metadata first would orphan
+    // cleanup cycle can retry; removing the metadata first would orphan
     // the Keystore entry with no way to find it again.
     val keystoreDeleted = try {
       val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/EnqueueResult.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/queue/EnqueueResult.kt
@@ -26,7 +26,7 @@ sealed class EnqueueResult {
     data class AnomalyRejected(val score: Float, val reasons: List<String>) : Rejected()
     /**
      * Field-level encryption was required but failed (Keystore unavailable,
-     * hardware fault, or corrupt key). Event NOT enqueued — plaintext PII is
+     * hardware fault, or corrupt key). Event NOT enqueued; plaintext PII is
      * never forwarded when this occurs.
      * @since 1.1.0
      */

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/transport/security/MtlsClientBuilder.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/transport/security/MtlsClientBuilder.kt
@@ -16,7 +16,7 @@ import javax.net.ssl.X509TrustManager
 
 /**
  * Thrown when mTLS configuration fails. The SDK does NOT silently downgrade to
- * unauthenticated TLS — callers that intend mTLS will see this exception and can
+ * unauthenticated TLS; callers that intend mTLS will see this exception and can
  * decide whether to retry, surface to an operator, or proceed explicitly.
  *
  * @since 1.1.0


### PR DESCRIPTION
Seven instances cleaned ahead of the v1.2.0 tag, per repo convention style.

Kotlin KDoc (em-dash to semicolon):
- `VersionedCryptoProvider.kt`
- `FieldLevelEncryptor.kt`
- `MtlsClientBuilder.kt`
- `EnqueueResult.kt`

Documentation (double-hyphen to colon or period):
- `ROADMAP.md`
- `docs/SECURE_DESIGN.md`
- `docs/VULNERABILITY_RESPONSE.md`

Test-source comments left as-is; internal only.

## Local verification
`./gradlew :kiosk-ops-sdk:apiCheck detekt`: green.