### PR TITLE
Simplify formatting in test sources

### DIFF
--- a/kiosk-ops-sdk/src/androidTest/java/com/sarastarquant/kioskops/sdk/crypto/KeystoreCryptoInstrumentedTest.kt
+++ b/kiosk-ops-sdk/src/androidTest/java/com/sarastarquant/kioskops/sdk/crypto/KeystoreCryptoInstrumentedTest.kt
@@ -67,7 +67,7 @@ class KeystoreCryptoInstrumentedTest {
     val plaintext = "sensitive-payload".toByteArray(Charsets.UTF_8)
     val encrypted = provider.encrypt(plaintext)
 
-    // The blob contains a version byte, IV length, IV, and ciphertext -- never the raw input.
+    // The blob contains a version byte, IV length, IV, and ciphertext: never the raw input.
     assertThat(encrypted).isNotEqualTo(plaintext)
     assertThat(encrypted.size).isGreaterThan(plaintext.size)
   }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkIntegrationTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkIntegrationTest.kt
@@ -70,7 +70,7 @@ class KioskOpsSdkIntegrationTest {
     )
   }
 
-  // -- enqueue pipeline end-to-end ------------------------------------------
+  // enqueue pipeline end-to-end ------------------------------------------
 
   @Test
   fun `enqueue returns true for valid event`() = runTest {
@@ -101,7 +101,7 @@ class KioskOpsSdkIntegrationTest {
     assertThat(sdk.queueDepth()).isEqualTo(2)
   }
 
-  // -- heartbeat ------------------------------------------------------------
+  // heartbeat ------------------------------------------------------------
 
   @Test
   fun `heartbeat completes without error`() = runTest {
@@ -110,7 +110,7 @@ class KioskOpsSdkIntegrationTest {
     sdk.heartbeat("integration_test")
   }
 
-  // -- health check ---------------------------------------------------------
+  // health check ---------------------------------------------------------
 
   @Test
   fun `healthCheck returns valid HealthCheckResult`() = runTest {
@@ -133,7 +133,7 @@ class KioskOpsSdkIntegrationTest {
     assertThat(health.queueDepth).isEqualTo(1)
   }
 
-  // -- config and policy ----------------------------------------------------
+  // config and policy ----------------------------------------------------
 
   @Test
   fun `currentConfig returns the configured values`() {
@@ -164,7 +164,7 @@ class KioskOpsSdkIntegrationTest {
     assertThat(hash1).isEqualTo(hash2)
   }
 
-  // -- device posture -------------------------------------------------------
+  // device posture -------------------------------------------------------
 
   @Test
   fun `devicePosture returns non-null posture`() {
@@ -175,7 +175,7 @@ class KioskOpsSdkIntegrationTest {
     assertThat(posture.manufacturer).isNotNull()
   }
 
-  // -- error listener -------------------------------------------------------
+  // error listener -------------------------------------------------------
 
   @Test
   fun `setErrorListener receives errors on sync failure`() = runTest {
@@ -212,7 +212,7 @@ class KioskOpsSdkIntegrationTest {
     assertThat(callbackCount).isEqualTo(0)
   }
 
-  // -- quarantined events ---------------------------------------------------
+  // quarantined events ---------------------------------------------------
 
   @Test
   fun `quarantinedEvents returns list`() = runTest {
@@ -222,7 +222,7 @@ class KioskOpsSdkIntegrationTest {
     assertThat(quarantined).isEmpty()
   }
 
-  // -- enqueue pipeline with multiple events --------------------------------
+  // enqueue pipeline with multiple events --------------------------------
 
   @Test
   fun `enqueueDetailed multiple events are all Accepted`() = runTest {
@@ -248,7 +248,7 @@ class KioskOpsSdkIntegrationTest {
     assertThat(r1.idempotencyKey).isNotEqualTo(r2.idempotencyKey)
   }
 
-  // -- heartbeat updates healthCheck ----------------------------------------
+  // heartbeat updates healthCheck ----------------------------------------
 
   @Test
   fun `heartbeat reason is reflected in healthCheck`() = runTest {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/audit/AuditTrailExtendedTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/audit/AuditTrailExtendedTest.kt
@@ -58,7 +58,7 @@ class AuditTrailExtendedTest {
     )
   }
 
-  // -- record() stores event with correct fields --
+  // record() stores event with correct fields --
 
   @Test
   fun `record stores event with correct name and timestamp`() {
@@ -89,7 +89,7 @@ class AuditTrailExtendedTest {
     assertThat(event.fields).hasSize(2)
   }
 
-  // -- Hash chain linking --
+  // Hash chain linking --
 
   @Test
   fun `first record uses GENESIS as prevHash`() {
@@ -137,7 +137,7 @@ class AuditTrailExtendedTest {
     assertThat(event.hash).isEqualTo(expectedHash)
   }
 
-  // -- record() with empty name --
+  // record() with empty name --
 
   @Test
   fun `record with empty name stores event with empty name field`() {
@@ -150,7 +150,7 @@ class AuditTrailExtendedTest {
     assertThat(event.name).isEmpty()
   }
 
-  // -- File-based day-slicing --
+  // File-based day-slicing --
 
   @Test
   fun `events on different days produce separate files`() {
@@ -192,7 +192,7 @@ class AuditTrailExtendedTest {
     assertThat(files[0].name).doesNotContain(".enc")
   }
 
-  // -- Retention enforcement --
+  // Retention enforcement --
 
   @Test
   fun `purgeOldFiles deletes files older than retention window`() {
@@ -284,7 +284,7 @@ class AuditTrailExtendedTest {
     assertThat(remaining[0].name).contains("2026-03-16")
   }
 
-  // -- Concurrent writes --
+  // Concurrent writes --
 
   @Test
   fun `concurrent writes do not corrupt state`() {
@@ -316,7 +316,7 @@ class AuditTrailExtendedTest {
     assertThat(totalLines).isEqualTo(threadCount * eventsPerThread)
   }
 
-  // -- listFiles ordering --
+  // listFiles ordering --
 
   @Test
   fun `listFiles returns files sorted by name`() {
@@ -358,7 +358,7 @@ class AuditTrailExtendedTest {
     assertThat(files).isEmpty()
   }
 
-  // -- Multiple records chain integrity --
+  // Multiple records chain integrity --
 
   @Test
   fun `chain of five records has correct linkage`() {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/DataRightsAuthorizerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/DataRightsAuthorizerTest.kt
@@ -55,10 +55,10 @@ class DataRightsAuthorizerTest {
     requireAuthorization = requireAuthorization,
   )
 
-  // -- 1. Authorizer allows export: operation proceeds, returns Success or NoData --
+  // 1. Authorizer allows export: operation proceeds, returns Success or NoData --
 
   @Test
-  fun `authorizer allows export -- operation proceeds and returns NoData for unknown user`() =
+  fun `authorizer allows export - operation proceeds and returns NoData for unknown user`() =
     runBlocking {
       val manager = buildManager()
       manager.setAuthorizer(DataRightsAuthorizer { _, _ -> true })
@@ -67,10 +67,10 @@ class DataRightsAuthorizerTest {
       assertThat(result).isInstanceOf(DataExportResult.NoData::class.java)
     }
 
-  // -- 2. Authorizer denies export: returns Unauthorized --
+  // 2. Authorizer denies export: returns Unauthorized --
 
   @Test
-  fun `authorizer denies export -- returns Unauthorized with EXPORT operation`() = runBlocking {
+  fun `authorizer denies export - returns Unauthorized with EXPORT operation`() = runBlocking {
     val manager = buildManager()
     manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
 
@@ -80,10 +80,10 @@ class DataRightsAuthorizerTest {
     assertThat(unauthorized.operation).isEqualTo(DataRightsOperation.EXPORT)
   }
 
-  // -- 3. Authorizer allows delete: operation proceeds --
+  // 3. Authorizer allows delete: operation proceeds --
 
   @Test
-  fun `authorizer allows delete -- operation proceeds and returns Success`() = runBlocking {
+  fun `authorizer allows delete - operation proceeds and returns Success`() = runBlocking {
     val manager = buildManager()
     manager.setAuthorizer(DataRightsAuthorizer { _, _ -> true })
 
@@ -91,10 +91,10 @@ class DataRightsAuthorizerTest {
     assertThat(result).isInstanceOf(DataDeletionResult.Success::class.java)
   }
 
-  // -- 4. Authorizer denies delete: returns Unauthorized --
+  // 4. Authorizer denies delete: returns Unauthorized --
 
   @Test
-  fun `authorizer denies delete -- returns Unauthorized with DELETE operation`() = runBlocking {
+  fun `authorizer denies delete - returns Unauthorized with DELETE operation`() = runBlocking {
     val manager = buildManager()
     manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
 
@@ -104,10 +104,10 @@ class DataRightsAuthorizerTest {
     assertThat(unauthorized.operation).isEqualTo(DataRightsOperation.DELETE)
   }
 
-  // -- 5. Authorizer allows wipe: operation proceeds --
+  // 5. Authorizer allows wipe: operation proceeds --
 
   @Test
-  fun `authorizer allows wipe -- operation proceeds and returns Success`() = runBlocking {
+  fun `authorizer allows wipe - operation proceeds and returns Success`() = runBlocking {
     val manager = buildManager()
     manager.setAuthorizer(DataRightsAuthorizer { _, _ -> true })
 
@@ -115,10 +115,10 @@ class DataRightsAuthorizerTest {
     assertThat(result).isInstanceOf(DataDeletionResult.Success::class.java)
   }
 
-  // -- 6. Authorizer denies wipe: returns Unauthorized --
+  // 6. Authorizer denies wipe: returns Unauthorized --
 
   @Test
-  fun `authorizer denies wipe -- returns Unauthorized with WIPE operation`() = runBlocking {
+  fun `authorizer denies wipe - returns Unauthorized with WIPE operation`() = runBlocking {
     val manager = buildManager()
     manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
 
@@ -128,10 +128,10 @@ class DataRightsAuthorizerTest {
     assertThat(unauthorized.operation).isEqualTo(DataRightsOperation.WIPE)
   }
 
-  // -- 7. No authorizer + requireAuthorization=false: operations proceed (backward compatible) --
+  // 7. No authorizer + requireAuthorization=false: operations proceed (backward compatible) --
 
   @Test
-  fun `no authorizer with requireAuthorization false -- export proceeds`() = runBlocking {
+  fun `no authorizer with requireAuthorization false - export proceeds`() = runBlocking {
     val manager = buildManager(requireAuthorization = false)
 
     val result = manager.exportUserData("user-compat")
@@ -139,7 +139,7 @@ class DataRightsAuthorizerTest {
   }
 
   @Test
-  fun `no authorizer with requireAuthorization false -- delete proceeds`() = runBlocking {
+  fun `no authorizer with requireAuthorization false - delete proceeds`() = runBlocking {
     val manager = buildManager(requireAuthorization = false)
 
     val result = manager.deleteUserData("user-compat")
@@ -147,17 +147,17 @@ class DataRightsAuthorizerTest {
   }
 
   @Test
-  fun `no authorizer with requireAuthorization false -- wipe proceeds`() = runBlocking {
+  fun `no authorizer with requireAuthorization false - wipe proceeds`() = runBlocking {
     val manager = buildManager(requireAuthorization = false)
 
     val result = manager.wipeAllSdkData()
     assertThat(result).isInstanceOf(DataDeletionResult.Success::class.java)
   }
 
-  // -- 8. No authorizer + requireAuthorization=true: operations return Unauthorized --
+  // 8. No authorizer + requireAuthorization=true: operations return Unauthorized --
 
   @Test
-  fun `no authorizer with requireAuthorization true -- export returns Unauthorized`() =
+  fun `no authorizer with requireAuthorization true - export returns Unauthorized`() =
     runBlocking {
       val manager = buildManager(requireAuthorization = true)
 
@@ -166,7 +166,7 @@ class DataRightsAuthorizerTest {
     }
 
   @Test
-  fun `no authorizer with requireAuthorization true -- delete returns Unauthorized`() =
+  fun `no authorizer with requireAuthorization true - delete returns Unauthorized`() =
     runBlocking {
       val manager = buildManager(requireAuthorization = true)
 
@@ -175,7 +175,7 @@ class DataRightsAuthorizerTest {
     }
 
   @Test
-  fun `no authorizer with requireAuthorization true -- wipe returns Unauthorized`() =
+  fun `no authorizer with requireAuthorization true - wipe returns Unauthorized`() =
     runBlocking {
       val manager = buildManager(requireAuthorization = true)
 
@@ -183,10 +183,10 @@ class DataRightsAuthorizerTest {
       assertThat(result).isInstanceOf(DataDeletionResult.Unauthorized::class.java)
     }
 
-  // -- 9. setAuthorizer(null) removes authorization: operations proceed if not required --
+  // 9. setAuthorizer(null) removes authorization: operations proceed if not required --
 
   @Test
-  fun `setAuthorizer null removes authorizer -- operations proceed when not required`() =
+  fun `setAuthorizer null removes authorizer - operations proceed when not required`() =
     runBlocking {
       val manager = buildManager(requireAuthorization = false)
       manager.setAuthorizer(DataRightsAuthorizer { _, _ -> false })
@@ -203,7 +203,7 @@ class DataRightsAuthorizerTest {
       assertThat(result).isInstanceOf(DataDeletionResult.Success::class.java)
     }
 
-  // -- 10. Authorizer receives correct operation type for each method --
+  // 10. Authorizer receives correct operation type for each method --
 
   @Test
   fun `authorizer receives EXPORT operation for exportUserData`() = runBlocking {
@@ -244,7 +244,7 @@ class DataRightsAuthorizerTest {
     assertThat(capturedOperation).isEqualTo(DataRightsOperation.WIPE)
   }
 
-  // -- 11. Authorizer receives correct userId for export and delete --
+  // 11. Authorizer receives correct userId for export and delete --
 
   @Test
   fun `authorizer receives correct userId for exportUserData`() = runBlocking {
@@ -272,7 +272,7 @@ class DataRightsAuthorizerTest {
     assertThat(capturedUserId).isEqualTo("target-user-delete")
   }
 
-  // -- 12. Authorizer receives empty userId for wipe --
+  // 12. Authorizer receives empty userId for wipe --
 
   @Test
   fun `authorizer receives empty userId for wipeAllSdkData`() = runBlocking {
@@ -287,7 +287,7 @@ class DataRightsAuthorizerTest {
     assertThat(capturedUserId).isEqualTo("")
   }
 
-  // -- 13. Unauthorized denial returns correct result (audit verified via return value) --
+  // 13. Unauthorized denial returns correct result (audit verified via return value) --
 
   @Test
   fun `authorizer denial for delete returns Unauthorized with DELETE operation`() = runBlocking {
@@ -299,7 +299,7 @@ class DataRightsAuthorizerTest {
     assertThat((result as DataDeletionResult.Unauthorized).operation).isEqualTo(DataRightsOperation.DELETE)
   }
 
-  // -- 14. No-authorizer block returns correct result --
+  // 14. No-authorizer block returns correct result --
 
   @Test
   fun `no authorizer with requireAuthorization returns Unauthorized for export`() =
@@ -310,7 +310,7 @@ class DataRightsAuthorizerTest {
       assertThat(result).isInstanceOf(DataExportResult.Unauthorized::class.java)
     }
 
-  // -- 15. cuiDefaults has requireDataRightsAuthorization=true --
+  // 15. cuiDefaults has requireDataRightsAuthorization=true --
 
   @Test
   fun `cuiDefaults sets requireDataRightsAuthorization to true`() {
@@ -321,7 +321,7 @@ class DataRightsAuthorizerTest {
     assertThat(config.requireDataRightsAuthorization).isTrue()
   }
 
-  // -- 16. cjisDefaults has requireDataRightsAuthorization=true --
+  // 16. cjisDefaults has requireDataRightsAuthorization=true --
 
   @Test
   fun `cjisDefaults sets requireDataRightsAuthorization to true`() {
@@ -332,7 +332,7 @@ class DataRightsAuthorizerTest {
     assertThat(config.requireDataRightsAuthorization).isTrue()
   }
 
-  // -- 17. gdprDefaults has requireDataRightsAuthorization=false --
+  // 17. gdprDefaults has requireDataRightsAuthorization=false --
 
   @Test
   fun `gdprDefaults sets requireDataRightsAuthorization to false`() {
@@ -343,7 +343,7 @@ class DataRightsAuthorizerTest {
     assertThat(config.requireDataRightsAuthorization).isFalse()
   }
 
-  // -- 18. fedRampDefaults has requireDataRightsAuthorization=false --
+  // 18. fedRampDefaults has requireDataRightsAuthorization=false --
 
   @Test
   fun `fedRampDefaults sets requireDataRightsAuthorization to false`() {
@@ -354,7 +354,7 @@ class DataRightsAuthorizerTest {
     assertThat(config.requireDataRightsAuthorization).isFalse()
   }
 
-  // -- 19. Default config has requireDataRightsAuthorization=false --
+  // 19. Default config has requireDataRightsAuthorization=false --
 
   @Test
   fun `default KioskOpsConfig has requireDataRightsAuthorization false`() {
@@ -366,7 +366,7 @@ class DataRightsAuthorizerTest {
     assertThat(config.requireDataRightsAuthorization).isFalse()
   }
 
-  // -- 20. Authorizer can be changed dynamically between operations --
+  // 20. Authorizer can be changed dynamically between operations --
 
   @Test
   fun `authorizer can be changed dynamically between operations`() = runBlocking {
@@ -383,7 +383,7 @@ class DataRightsAuthorizerTest {
     assertThat(allowed).isInstanceOf(DataDeletionResult.Success::class.java)
   }
 
-  // -- Additional coverage: selective authorizer allows some operations but not others --
+  // Additional coverage: selective authorizer allows some operations but not others --
 
   @Test
   fun `authorizer can selectively allow export but deny delete`() = runBlocking {
@@ -422,7 +422,7 @@ class DataRightsAuthorizerTest {
     val allowed = manager.deleteUserData("user-null-req")
     assertThat(allowed).isInstanceOf(DataDeletionResult.Success::class.java)
 
-    // Remove authorizer -- should block since requireAuthorization=true
+    // Remove authorizer: should block since requireAuthorization=true
     manager.setAuthorizer(null)
     val blocked = manager.deleteUserData("user-null-req")
     assertThat(blocked).isInstanceOf(DataDeletionResult.Unauthorized::class.java)

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/ConditionalCryptoProviderTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/ConditionalCryptoProviderTest.kt
@@ -61,7 +61,7 @@ class ConditionalCryptoProviderTest {
   }
 
   // -------------------------------------------------------------------------
-  // Encrypt -- delegate called when enabled; passthrough when disabled
+  // Encrypt: delegate called when enabled; passthrough when disabled
   // -------------------------------------------------------------------------
 
   @Test
@@ -96,7 +96,7 @@ class ConditionalCryptoProviderTest {
   }
 
   // -------------------------------------------------------------------------
-  // Decrypt -- delegate called when enabled; passthrough when disabled
+  // Decrypt: delegate called when enabled; passthrough when disabled
   // -------------------------------------------------------------------------
 
   @Test

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/VersionedCryptoProviderTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/VersionedCryptoProviderTest.kt
@@ -74,7 +74,7 @@ class VersionedCryptoProviderTest {
   }
 
   // ---------------------------------------------------------------------------
-  // shouldRotate -- policy-driven, does not touch Keystore
+  // shouldRotate: policy-driven, does not touch Keystore
   // ---------------------------------------------------------------------------
 
   @Test
@@ -176,7 +176,7 @@ class VersionedCryptoProviderTest {
   }
 
   // ---------------------------------------------------------------------------
-  // rotateKey -- Keystore operations will fail, but policy guard is testable
+  // rotateKey: Keystore operations will fail, but policy guard is testable
   // ---------------------------------------------------------------------------
 
   @Test
@@ -264,7 +264,7 @@ class VersionedCryptoProviderTest {
   }
 
   // ---------------------------------------------------------------------------
-  // decrypt -- blob validation (rejects malformed blobs before Keystore call)
+  // decrypt: blob validation (rejects malformed blobs before Keystore call)
   // ---------------------------------------------------------------------------
 
   @Test(expected = IllegalArgumentException::class)
@@ -319,7 +319,7 @@ class VersionedCryptoProviderTest {
     try {
       provider.decrypt(blob)
       // If we get here without exception, the Robolectric AndroidKeyStore
-      // shadow loaded -- that is acceptable but uncommon
+      // shadow loaded: that is acceptable but uncommon
     } catch (e: IllegalStateException) {
       assertThat(e.message).contains("not available")
     } catch (_: Exception) {
@@ -328,7 +328,7 @@ class VersionedCryptoProviderTest {
   }
 
   // ---------------------------------------------------------------------------
-  // encrypt -- header validation (Keystore will fail, but we verify the attempt)
+  // encrypt: header validation (Keystore will fail, but we verify the attempt)
   // ---------------------------------------------------------------------------
 
   @Test
@@ -338,12 +338,12 @@ class VersionedCryptoProviderTest {
       provider.encrypt("hello".toByteArray())
       // Unlikely to succeed without AndroidKeyStore
     } catch (_: Exception) {
-      // Expected -- AndroidKeyStore not available in Robolectric
+      // Expected: AndroidKeyStore not available in Robolectric
     }
   }
 
   // ---------------------------------------------------------------------------
-  // Blob format -- software implementation for round-trip testing
+  // Blob format: software implementation for round-trip testing
   // ---------------------------------------------------------------------------
 
   @Test

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/geofence/GeofenceManagerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/geofence/GeofenceManagerTest.kt
@@ -649,7 +649,7 @@ class GeofenceManagerTest {
     manager.removeTransitionListener(listener)
     manager.handleTransition("region-b", TransitionType.ENTER)
 
-    // Should still be 1 -- region-b notification was not delivered
+    // Should still be 1: region-b notification was not delivered
     assertThat(enteredRegions).hasSize(1)
   }
 
@@ -718,7 +718,7 @@ class GeofenceManagerTest {
       manager.handleTransition("r2", TransitionType.ENTER)
       assertThat(manager.getCurrentProfileName()).isEqualTo("shared-profile")
 
-      // Exit highest priority -- r1 still active with same profile
+      // Exit highest priority: r1 still active with same profile
       manager.handleTransition("r2", TransitionType.EXIT)
       assertThat(manager.getCurrentProfileName()).isEqualTo("shared-profile")
       assertThat(manager.getActiveRegionIds()).containsExactly("r1")

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/observability/metrics/MetricRegistryExtendedTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/observability/metrics/MetricRegistryExtendedTest.kt
@@ -21,7 +21,7 @@ class MetricRegistryExtendedTest {
     registry = MetricRegistry()
   }
 
-  // -- Counter tests --
+  // Counter tests --
 
   @Test
   fun `counter add and getValue returns correct total`() {
@@ -71,7 +71,7 @@ class MetricRegistryExtendedTest {
     assertThat(counter.getValues()).isEmpty()
   }
 
-  // -- Gauge tests --
+  // Gauge tests --
 
   @Test
   fun `gauge record and getValue returns latest value`() {
@@ -120,7 +120,7 @@ class MetricRegistryExtendedTest {
     assertThat(gauge.getValues()[emptyMap()]).isEqualTo(-15.5)
   }
 
-  // -- Histogram tests --
+  // Histogram tests --
 
   @Test
   fun `histogram record and statistics are correct`() {
@@ -213,7 +213,7 @@ class MetricRegistryExtendedTest {
     assertThat(values[mapOf("region" to "eu")]!!.sum).isEqualTo(20.0)
   }
 
-  // -- BucketSnapshot --
+  // BucketSnapshot --
 
   @Test
   fun `BucketSnapshot average with multiple values`() {
@@ -241,7 +241,7 @@ class MetricRegistryExtendedTest {
     assertThat(snapshot.average).isEqualTo(0.0)
   }
 
-  // -- collectMetrics (getAll) --
+  // collectMetrics (getAll) --
 
   @Test
   fun `collectMetrics returns all registered metrics`() {
@@ -265,7 +265,7 @@ class MetricRegistryExtendedTest {
     assertThat(snapshot.histograms).isEmpty()
   }
 
-  // -- reset clears all metrics --
+  // reset clears all metrics --
 
   @Test
   fun `reset clears values across all metric types`() {
@@ -284,7 +284,7 @@ class MetricRegistryExtendedTest {
     assertThat(histogram.getValues()).isEmpty()
   }
 
-  // -- Concurrent counter increments --
+  // Concurrent counter increments --
 
   @Test
   fun `concurrent counter increments produce correct total`() {
@@ -341,7 +341,7 @@ class MetricRegistryExtendedTest {
     assertThat(values).isNotEmpty()
   }
 
-  // -- Metric name uniqueness --
+  // Metric name uniqueness --
 
   @Test
   fun `getOrCreateCounter returns same instance for same name`() {
@@ -376,7 +376,7 @@ class MetricRegistryExtendedTest {
     assertThat(gauge.getValues()[emptyMap()]).isEqualTo(99.0)
   }
 
-  // -- Counter and gauge name/description/unit properties --
+  // Counter and gauge name/description/unit properties --
 
   @Test
   fun `counter preserves name description and unit`() {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/observability/metrics/PrometheusExporterExtendedTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/observability/metrics/PrometheusExporterExtendedTest.kt
@@ -20,7 +20,7 @@ class PrometheusExporterExtendedTest {
     exporter = PrometheusExporter(registry)
   }
 
-  // -- Counter export format --
+  // Counter export format --
 
   @Test
   fun `counter export includes TYPE and HELP lines`() {
@@ -60,7 +60,7 @@ class PrometheusExporterExtendedTest {
     assertThat(output).contains("# TYPE no_desc counter")
   }
 
-  // -- Gauge export format --
+  // Gauge export format --
 
   @Test
   fun `gauge export includes TYPE and HELP lines`() {
@@ -91,7 +91,7 @@ class PrometheusExporterExtendedTest {
     assertThat(output).contains("temperature{floor=\"2\",sensor=\"main\"} 22.5")
   }
 
-  // -- Export with labels --
+  // Export with labels --
 
   @Test
   fun `export with multiple labels sorts them alphabetically`() {
@@ -130,7 +130,7 @@ class PrometheusExporterExtendedTest {
     assertThat(output).contains("say \\\"hello\\\"")
   }
 
-  // -- Export multiple metrics --
+  // Export multiple metrics --
 
   @Test
   fun `export multiple counters`() {
@@ -181,7 +181,7 @@ class PrometheusExporterExtendedTest {
     assertThat(output).contains("http_total{method=\"POST\"} 30.0")
   }
 
-  // -- Export empty registry --
+  // Export empty registry --
 
   @Test
   fun `export empty registry returns empty string`() {
@@ -196,7 +196,7 @@ class PrometheusExporterExtendedTest {
     assertThat(output).contains("# Exported at:")
   }
 
-  // -- Sanitized metric names --
+  // Sanitized metric names --
 
   @Test
   fun `metric name with dots replaced by underscores`() {
@@ -236,7 +236,7 @@ class PrometheusExporterExtendedTest {
     assertThat(output).contains("host_name=\"server-1\"")
   }
 
-  // -- Histogram export format --
+  // Histogram export format --
 
   @Test
   fun `histogram export has cumulative bucket counts`() {
@@ -286,7 +286,7 @@ class PrometheusExporterExtendedTest {
     assertThat(output).doesNotContain("empty_hist_bucket")
   }
 
-  // -- CONTENT_TYPE constant --
+  // CONTENT_TYPE constant --
 
   @Test
   fun `CONTENT_TYPE is valid Prometheus format`() {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/pipeline/FederalPipelineTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/pipeline/FederalPipelineTest.kt
@@ -91,7 +91,7 @@ class FederalPipelineTest : PipelineTestBase() {
     """.trimIndent()
     sdk.schemaRegistry.register("audit.action", schema)
 
-    // Missing required "action" field -- validation should reject before PII scan
+    // Missing required "action" field: validation should reject before PII scan
     val result = sdk.enqueueDetailed("audit.action", """{"notes": "incomplete"}""")
 
     assertThat(result).isInstanceOf(EnqueueResult.Rejected.ValidationFailed::class.java)

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/pipeline/ValidationRejectionTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/pipeline/ValidationRejectionTest.kt
@@ -98,7 +98,7 @@ class ValidationRejectionTest : PipelineTestBase() {
     """.trimIndent()
     sdk.schemaRegistry.register("payment.processed", schema)
 
-    // Missing required "amount" field -- permissive mode does not reject
+    // Missing required "amount" field: permissive mode does not reject
     val result = sdk.enqueueDetailed("payment.processed", """{"note": "no amount"}""")
 
     assertThat(result).isInstanceOf(EnqueueResult.Accepted::class.java)
@@ -161,7 +161,7 @@ class ValidationRejectionTest : PipelineTestBase() {
   }
 
   // ==========================================================================
-  // Edge cases -- validation-related
+  // Edge cases: validation-related
   // ==========================================================================
 
   @Test

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/CertificatePinningHostMatchTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/CertificatePinningHostMatchTest.kt
@@ -34,7 +34,7 @@ class CertificatePinningHostMatchTest {
   }
 
   // ---------------------------------------------------------------------------
-  // hasPinsForHost / matchesHostname -- tested indirectly through intercept()
+  // hasPinsForHost / matchesHostname: tested indirectly through intercept()
   // ---------------------------------------------------------------------------
 
   @Test
@@ -60,7 +60,7 @@ class CertificatePinningHostMatchTest {
   fun `wildcard hostname match triggers pin validation for single-level subdomain`() {
     server.enqueue(MockResponse.Builder().code(200).body("ok").build())
 
-    // Pin *.localhost -- if the server hostname is "api.localhost", it should match
+    // Pin *.localhost: if the server hostname is "api.localhost", it should match
     // In practice, we test this by pinning *.example.com and requesting a
     // non-pinned host to show passthrough vs pinned behavior
     val interceptor = CertificatePinningInterceptor(
@@ -99,7 +99,7 @@ class CertificatePinningHostMatchTest {
   }
 
   // ---------------------------------------------------------------------------
-  // matchesHostname -- wildcard edge cases via fromPolicy + intercept behavior
+  // matchesHostname: wildcard edge cases via fromPolicy + intercept behavior
   // ---------------------------------------------------------------------------
 
   @Test
@@ -148,14 +148,14 @@ class CertificatePinningHostMatchTest {
   }
 
   // ---------------------------------------------------------------------------
-  // matchesHostname -- unit-level via dedicated interceptors
+  // matchesHostname: unit-level via dedicated interceptors
   // ---------------------------------------------------------------------------
 
   @Test
   fun `matchesHostname exact match verified via pin failure`() {
     server.enqueue(MockResponse.Builder().code(200).body("ok").build())
 
-    // Exact-match "localhost" -- should trigger pin check and fail
+    // Exact-match "localhost": should trigger pin check and fail
     val interceptor = CertificatePinningInterceptor(
       pins = listOf(
         CertificatePin("localhost", listOf("sha256/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ="))
@@ -174,7 +174,7 @@ class CertificatePinningHostMatchTest {
     server.enqueue(MockResponse.Builder().code(200).body("ok").build())
 
     // "example.com" should NOT match "api.example.com"
-    // Use a host that is exactly "example.com" -- since server is localhost,
+    // Use a host that is exactly "example.com": since server is localhost,
     // localhost won't match example.com and will pass through.
     val interceptor = CertificatePinningInterceptor(
       pins = listOf(
@@ -190,7 +190,7 @@ class CertificatePinningHostMatchTest {
   }
 
   // ---------------------------------------------------------------------------
-  // hasPinsForHost -- wildcard matching edge cases via constructor + intercept
+  // hasPinsForHost: wildcard matching edge cases via constructor + intercept
   // ---------------------------------------------------------------------------
 
   @Test
@@ -206,7 +206,7 @@ class CertificatePinningHostMatchTest {
     )
     val client = OkHttpClient.Builder().addInterceptor(interceptor).build()
 
-    // "localhost" does not match "*.localhost" -- should pass through
+    // "localhost" does not match "*.localhost": should pass through
     val response = client.newCall(
       Request.Builder().url(server.url("/wildcard-bare")).build()
     ).execute()

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/CertificatePinningInterceptTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/CertificatePinningInterceptTest.kt
@@ -36,7 +36,7 @@ class CertificatePinningInterceptTest {
   }
 
   // ---------------------------------------------------------------------------
-  // intercept() -- unpinned host passthrough (hasPinsForHost returns false)
+  // intercept(): unpinned host passthrough (hasPinsForHost returns false)
   // ---------------------------------------------------------------------------
 
   @Test
@@ -75,7 +75,7 @@ class CertificatePinningInterceptTest {
   }
 
   // ---------------------------------------------------------------------------
-  // intercept() -- pin validation failure invokes callback and throws
+  // intercept(): pin validation failure invokes callback and throws
   // ---------------------------------------------------------------------------
 
   @Test
@@ -102,7 +102,7 @@ class CertificatePinningInterceptTest {
         Request.Builder().url(server.url("/pinned")).build()
       ).execute()
     } catch (_: Exception) {
-      // Expected -- pin mismatch
+      // Expected: pin mismatch
     }
 
     assertThat(callbackHostname).isEqualTo("localhost")
@@ -178,14 +178,14 @@ class CertificatePinningInterceptTest {
   }
 
   // ---------------------------------------------------------------------------
-  // intercept() -- pin format normalization exercised via real request
+  // intercept(): pin format normalization exercised via real request
   // ---------------------------------------------------------------------------
 
   @Test
   fun `intercept with pin missing sha256 prefix still validates`() {
     server.enqueue(MockResponse.Builder().code(200).body("ok").build())
 
-    // Pin without sha256/ prefix -- buildPinner should add it
+    // Pin without sha256/ prefix: buildPinner should add it
     val interceptor = CertificatePinningInterceptor(
       pins = listOf(
         CertificatePin("localhost", listOf("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
@@ -206,7 +206,7 @@ class CertificatePinningInterceptTest {
   }
 
   // ---------------------------------------------------------------------------
-  // intercept() -- successful request passthrough when no pins for host
+  // intercept(): successful request passthrough when no pins for host
   // ---------------------------------------------------------------------------
 
   @Test
@@ -272,7 +272,7 @@ class CertificatePinningInterceptTest {
   }
 
   // ---------------------------------------------------------------------------
-  // intercept() -- multiple pins per host, multiple hosts
+  // intercept(): multiple pins per host, multiple hosts
   // ---------------------------------------------------------------------------
 
   @Test
@@ -319,7 +319,7 @@ class CertificatePinningInterceptTest {
   }
 
   // ---------------------------------------------------------------------------
-  // intercept() -- callback details
+  // intercept(): callback details
   // ---------------------------------------------------------------------------
 
   @Test
@@ -373,7 +373,7 @@ class CertificatePinningInterceptTest {
   }
 
   // ---------------------------------------------------------------------------
-  // intercept() -- request method variations
+  // intercept(): request method variations
   // ---------------------------------------------------------------------------
 
   @Test
@@ -438,7 +438,7 @@ class CertificatePinningInterceptTest {
     )
     val client = OkHttpClient.Builder().addInterceptor(interceptor).build()
 
-    // Both pins are normalized but neither matches the real cert -- should fail
+    // Both pins are normalized but neither matches the real cert: should fail
     val thrown = assertThrows(Exception::class.java) {
       client.newCall(Request.Builder().url(server.url("/mixed")).build()).execute()
     }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/CertificatePinningPolicyTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/CertificatePinningPolicyTest.kt
@@ -14,7 +14,7 @@ import org.robolectric.RobolectricTestRunner
 class CertificatePinningPolicyTest {
 
   // ---------------------------------------------------------------------------
-  // fromPolicy() -- companion factory
+  // fromPolicy(): companion factory
   // ---------------------------------------------------------------------------
 
   @Test
@@ -63,7 +63,7 @@ class CertificatePinningPolicyTest {
   }
 
   // ---------------------------------------------------------------------------
-  // buildPinner() -- sha256 prefix normalization (tested indirectly)
+  // buildPinner(): sha256 prefix normalization (tested indirectly)
   // ---------------------------------------------------------------------------
 
   @Test
@@ -126,7 +126,7 @@ class CertificatePinningPolicyTest {
   }
 
   // ---------------------------------------------------------------------------
-  // fromPolicy -- edge cases
+  // fromPolicy: edge cases
   // ---------------------------------------------------------------------------
 
   @Test

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/CtValidationTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/CtValidationTest.kt
@@ -155,7 +155,7 @@ class CtValidationTest {
   }
 
   // ---------------------------------------------------------------
-  // intercept() -- disabled path
+  // intercept(): disabled path
   // ---------------------------------------------------------------
 
   @Test
@@ -180,7 +180,7 @@ class CtValidationTest {
   }
 
   // ---------------------------------------------------------------
-  // intercept() -- enabled, no handshake
+  // intercept(): enabled, no handshake
   // ---------------------------------------------------------------
 
   @Test
@@ -194,7 +194,7 @@ class CtValidationTest {
   }
 
   // ---------------------------------------------------------------
-  // intercept() -- enabled, handshake with empty certificate list
+  // intercept(): enabled, handshake with empty certificate list
   // ---------------------------------------------------------------
 
   @Test
@@ -208,7 +208,7 @@ class CtValidationTest {
   }
 
   // ---------------------------------------------------------------
-  // hasEmbeddedScts() -- OID 1.3.6.1.4.1.11129.2.4.2
+  // hasEmbeddedScts(): OID 1.3.6.1.4.1.11129.2.4.2
   // ---------------------------------------------------------------
 
   @Test
@@ -389,7 +389,7 @@ class CtValidationTest {
   }
 
   // ---------------------------------------------------------------
-  // Multi-certificate chain -- leaf is validated
+  // Multi-certificate chain: leaf is validated
   // ---------------------------------------------------------------
 
   @Test
@@ -423,7 +423,7 @@ class CtValidationTest {
 
   @Test
   fun `certificate with SCT from unknown CA passes validation`() {
-    // Has SCT but issuer is not a known CA -- should still pass
+    // Has SCT but issuer is not a known CA: should still pass
     val cert = stubCert("CN=Unknown Private CA, O=Private Org", hasSct = true)
     val validator = CertificateTransparencyValidator(enabled = true)
     val chain = buildFakeChain(certificates = listOf(cert))

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/MtlsClientBuilderTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/transport/security/MtlsClientBuilderTest.kt
@@ -65,7 +65,7 @@ class MtlsClientBuilderTest {
 
   /**
    * Generate a CA certificate and a leaf certificate signed by that CA.
-   * Returns (leafCert, leafKey, caCert) -- the caCert serves as an
+   * Returns (leafCert, leafKey, caCert); the caCert serves as an
    * intermediate in the chain.
    */
   @Suppress("LongMethod")
@@ -414,7 +414,7 @@ class MtlsClientBuilderTest {
   }
 
   // ---------------------------------------------------------------
-  // getDefaultTrustManager() -- tested via reflection
+  // getDefaultTrustManager(): tested via reflection
   // ---------------------------------------------------------------
 
   @Test
@@ -436,7 +436,7 @@ class MtlsClientBuilderTest {
   }
 
   // ---------------------------------------------------------------
-  // createSslContext() -- tested via reflection
+  // createSslContext(): tested via reflection
   // ---------------------------------------------------------------
 
   @Test

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/DiagnosticsWorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/DiagnosticsWorkerTest.kt
@@ -75,7 +75,7 @@ class DiagnosticsWorkerTest {
   }
 
   // -------------------------------------------------------------------------
-  // doWork -- SDK not initialized
+  // doWork: SDK not initialized
   // -------------------------------------------------------------------------
 
   @Test
@@ -86,7 +86,7 @@ class DiagnosticsWorkerTest {
   }
 
   // -------------------------------------------------------------------------
-  // doWork -- scheduled disabled
+  // doWork: scheduled disabled
   // -------------------------------------------------------------------------
 
   @Test
@@ -111,7 +111,7 @@ class DiagnosticsWorkerTest {
       DiagnosticsSchedulePolicy.enterpriseDefaults()
     )
 
-    // Then schedule with disabled policy -- should cancel
+    // Then schedule with disabled policy: should cancel
     DiagnosticsSchedulerWorker.schedule(
       ctx,
       DiagnosticsSchedulePolicy.disabledDefaults()
@@ -203,7 +203,7 @@ class DiagnosticsWorkerTest {
       DiagnosticsSchedulePolicy.enterpriseDefaults()
     )
 
-    // Re-schedule with weekly defaults -- should replace (UPDATE policy)
+    // Re-schedule with weekly defaults: should replace (UPDATE policy)
     DiagnosticsSchedulerWorker.schedule(
       ctx,
       DiagnosticsSchedulePolicy.weeklyDefaults()

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/WorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/WorkerTest.kt
@@ -87,7 +87,7 @@ class WorkerTest {
     initSdk()
     val worker = TestListenableWorkerBuilder<KioskOpsEventSyncWorker>(ctx).build()
     val result = worker.doWork()
-    // PermanentFailure maps to success() (no retry -- operator must fix config)
+    // PermanentFailure maps to success() (no retry: operator must fix config)
     assertThat(result).isEqualTo(ListenableWorker.Result.success())
   }
 }


### PR DESCRIPTION
Continuation of #106 for internal test files.

- Section-divider prefixes `// -- ` stripped.
- Mid-line separators `A -- B` replaced with `A: B` in comments.
- Same pattern in backtick test names replaced with `A - B` (Kotlin rejects `:` inside backticks).

18 test files, 119 lines, test-source only. No effect on any published artifact.

## Local verification
`./gradlew :kiosk-ops-sdk:testDebugUnitTest`: green.