### PR TITLE
Disable SDK lifecycle observer registration in unit tests

### DIFF
--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
@@ -1292,10 +1292,12 @@ class KioskOpsSdk private constructor(
         created.queue.reconcileStaleSending(staleBefore)
       }
       created.applySchedulingFromConfig()
-      com.sarastarquant.kioskops.sdk.lifecycle.SdkLifecycleObserver.register(
-        sdkProvider = { INSTANCE },
-        scope = created.javaInteropScope,
-      )
+      if (!skipLifecycleObserverRegistrationForTesting) {
+        com.sarastarquant.kioskops.sdk.lifecycle.SdkLifecycleObserver.register(
+          sdkProvider = { INSTANCE },
+          scope = created.javaInteropScope,
+        )
+      }
       return created
     }
 
@@ -1310,5 +1312,14 @@ class KioskOpsSdk private constructor(
       INSTANCE?.sdkJob?.cancel()
       INSTANCE = null
     }
+
+    // Robolectric shares a ProcessLifecycleOwner singleton across test classes. Each
+    // init() call registers a new observer; observers from prior test classes persist
+    // and fire heartbeat("app_backgrounded") on the current INSTANCE when Robolectric
+    // synthesizes onStop events. That races with tests that read lastHeartbeatReason.
+    // Production code never sets this; tests that exercise init() via Robolectric do.
+    @androidx.annotation.VisibleForTesting
+    @Volatile
+    internal var skipLifecycleObserverRegistrationForTesting: Boolean = false
   }
 }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/BlockingWrapperTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/BlockingWrapperTest.kt
@@ -53,6 +53,7 @@ class BlockingWrapperTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   @Test

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/FlowApisTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/FlowApisTest.kt
@@ -45,6 +45,7 @@ class FlowApisTest {
       ctx, Configuration.Builder().setMinimumLoggingLevel(android.util.Log.DEBUG).build()
     )
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
     KioskOpsSdk.init(
       context = ctx,
       configProvider = { testConfig },

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/HealthCheckAndErrorListenerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/HealthCheckAndErrorListenerTest.kt
@@ -34,6 +34,7 @@ class HealthCheckAndErrorListenerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk(): KioskOpsSdk {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkInitTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkInitTest.kt
@@ -44,6 +44,7 @@ class KioskOpsSdkInitTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   @Test

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkIntegrationTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkIntegrationTest.kt
@@ -46,6 +46,7 @@ class KioskOpsSdkIntegrationTest {
   @Before
   fun setUp() {
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
     ctx = ApplicationProvider.getApplicationContext()
     ctx.deleteDatabase("kiosk_ops_queue.db")
     ctx.deleteDatabase("kioskops_audit.db")

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/SdkLifecycleTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/SdkLifecycleTest.kt
@@ -42,6 +42,7 @@ class SdkLifecycleTest {
       ctx, Configuration.Builder().setMinimumLoggingLevel(android.util.Log.DEBUG).build()
     )
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   @After

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/pipeline/PipelineTestBase.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/pipeline/PipelineTestBase.kt
@@ -37,6 +37,7 @@ abstract class PipelineTestBase {
   @Before
   open fun setUp() {
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
     ctx = ApplicationProvider.getApplicationContext()
     ctx.deleteDatabase("kiosk_ops_queue.db")
     ctx.deleteDatabase("kioskops_audit.db")

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/DiagnosticsWorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/DiagnosticsWorkerTest.kt
@@ -52,6 +52,7 @@ class DiagnosticsWorkerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk(diagnosticsPolicy: DiagnosticsSchedulePolicy = DiagnosticsSchedulePolicy.disabledDefaults()) {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/EventSyncWorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/EventSyncWorkerTest.kt
@@ -51,6 +51,7 @@ class EventSyncWorkerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk(syncEnabled: Boolean = false) {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/SyncWorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/SyncWorkerTest.kt
@@ -50,6 +50,7 @@ class SyncWorkerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk() {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/WorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/WorkerTest.kt
@@ -38,6 +38,7 @@ class WorkerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk() {


### PR DESCRIPTION
`KioskOpsSdkIntegrationTest.heartbeat reason is reflected in healthCheck` was flaky on CI: passed locally but failed intermittently on clean CI runs.

## Root cause
`SdkLifecycleObserver.register` adds an observer to the `ProcessLifecycleOwner` singleton, which Robolectric shares across test classes. Each `init()` call registers a new observer; observers from prior test classes persist past `resetForTesting()` and fire against the new INSTANCE when Robolectric synthesizes `onStop` events. The handler launches `heartbeat("app_backgrounded")` on `javaInteropScope` (real `Dispatchers.IO`, not the test dispatcher), overwriting `lastHeartbeatReason` between the test's two explicit heartbeat calls.

## Fix
`@VisibleForTesting internal var skipLifecycleObserverRegistrationForTesting` on `KioskOpsSdk.Companion`, default false. Production never sets it. Eleven test files that call `KioskOpsSdk.init` set it to true immediately after `resetForTesting()` in `@Before`.

## Verification
`./gradlew :kiosk-ops-sdk:testDebugUnitTest :kiosk-ops-sdk:apiCheck detekt :sample-app:assembleDebug`: green.
Flake test re-run locally: 5/5 pass.

## API surface
`skipLifecycleObserverRegistrationForTesting` is `internal` and `@VisibleForTesting`; not in the public API dump.