### PR TITLE
Add release verification checklist and pre-tag script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,13 +157,6 @@ asked for. No breaking changes; one source-compat nuance on
   consumers continue to resolve. `queueDepthFlow(Long)` retains its
   signature so the `$default` synthetic is unchanged.
 
-### Known issues
-
-- `KioskOpsSdkIntegrationTest.heartbeat reason is reflected in healthCheck`
-  is intermittently flaky on CI; passes consistently locally. Tracked for
-  v1.3.0 to refactor the Robolectric test isolation. Does not affect SDK
-  behavior.
-
 ## [1.1.0] - 2026-04-18
 
 Security hardening release. Fixes several audit-surfaced confidentiality and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -447,6 +447,18 @@ earned after 1.2. Deferred from the original v1.2 scope.
 - [ ] `KioskOpsConfig.toString()` multi-line redacted pretty-print
 - [ ] Detekt baseline-rot CI guard
 
+### Release verification infrastructure
+- [ ] Backward-compatibility fixture: pinned copy of sample-app at the
+  previous minor, buildable against the current AAR. Makes
+  `docs/RELEASE_VERIFICATION.md` IP5 mechanical.
+- [ ] Mock-server harness (MockWebServer wrapper with certificate rotation
+  and body-delay). Makes IP2 and IP4 scripted.
+- [ ] Performance benchmarks via androidx.benchmark for `heartbeat`,
+  `enqueue`, and the sync batch-send hot path. Catches silent regressions.
+- [ ] Extend `scripts/pre-release-verify.sh` to drive Robolectric-based
+  subsets of IP3 (database corruption) and IP4 (process-kill mid-sync) so
+  the drills run at CI time instead of only pre-tag.
+
 ### Documentation
 - [ ] `FEATURES.md` flattened capability matrix (Feature | Default |
   Since | Link)

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -1,0 +1,209 @@
+# Release Verification
+
+Pre-tag checklist for KioskOps SDK releases. Keeps release verification reproducible
+across versions and across maintainers. Required reading before pushing any
+`v*.*.*` tag.
+
+> **Scope.** Engineering gates only. Business gates (release announcement, customer
+> outreach) are out of scope.
+
+## How to use this document
+
+Work top-down. Items in **Blocking before tag push** and **Blocking on tag push**
+must all pass before the tag goes public. Items in **Post-tag drills** run in the
+window between tag push and public announcement; a failure there means revoking
+the release (delete the tag, unpublish the GitHub Release, file an advisory) and
+cutting a patch.
+
+`scripts/pre-release-verify.sh` automates the shell-runnable subset. Run it first;
+use this document as the source of truth for the rest.
+
+## Blocking before tag push
+
+### Code correctness
+
+Already exercised by CI on every PR; re-run locally against the release candidate
+commit.
+
+| Check | Command | Pass criteria |
+|---|---|---|
+| Unit tests | `./gradlew :kiosk-ops-sdk:testDebugUnitTest` | 100% |
+| API surface | `./gradlew :kiosk-ops-sdk:apiCheck` | Clean; baseline matches `main` HEAD |
+| Static analysis | `./gradlew :kiosk-ops-sdk:detekt` | Zero new issues vs baseline |
+| Sample app debug + release | `./gradlew :sample-app:assembleDebug :sample-app:assembleRelease` | Both configurations build |
+| Coverage floor | `./gradlew :kiosk-ops-sdk:koverVerifyDebug` | Kover rule `minBound(70)` holds |
+| Dokka | `./gradlew :kiosk-ops-sdk:dokkaGeneratePublicationHtml` | Exits clean |
+
+### Release artifact verification
+
+Performed against the local-publish output before tagging.
+
+**Maven Local dry-run.**
+
+```
+./gradlew :kiosk-ops-sdk:publishToMavenLocal
+```
+
+Inspect `~/.m2/repository/com/sarastarquant/kioskops/kiosk-ops-sdk/<version>/`:
+
+- `kiosk-ops-sdk-<version>.aar` is non-empty.
+- `kiosk-ops-sdk-<version>.pom` references verification (SCM, developer, and URL
+  fields point at the current repository owner).
+- `kiosk-ops-sdk-<version>.module` (Gradle Module Metadata) references the
+  transitive deps we intend to ship.
+- `kiosk-ops-sdk-<version>-sources.jar` contains `.kt` files.
+- `kiosk-ops-sdk-<version>-javadoc.jar` is the Dokka HTML, not an empty
+  placeholder.
+
+**SBOM content audit.**
+
+```
+./gradlew :kiosk-ops-sdk:cyclonedxBom
+jq '.components[] | select(.scope=="required") | .purl' kiosk-ops-sdk/build/reports/bom.json | sort -u
+```
+
+Match the expected runtime closure. Flag anything surprising. For v1.2:
+
+- No `org.bouncycastle:*` runtime (build-classpath only; forced to 1.84).
+- No `com.appmattus.certificatetransparency:*` (removed in 1.2).
+- Kotlin stdlib, kotlinx-serialization-json, androidx.room, okhttp at the
+  versions pinned in `gradle/libs.versions.toml`.
+
+**AAR surface audit.**
+
+```
+unzip -l kiosk-ops-sdk/build/outputs/aar/kiosk-ops-sdk-release.aar
+```
+
+- `classes.jar` contains no `net.zetetic.database.sqlcipher.*` (SQLCipher is
+  `compileOnly`).
+- `classes.jar` contains no `com.appmattus.*`.
+- `AndroidManifest.xml` declares zero `<activity>`, exactly one `<provider>`
+  (the androidx.startup InitializationProvider).
+- `proguard.txt` is the consumer rules, non-empty.
+- No class matching `.*Test.*`, `.*Fake.*`, `.*Mock.*`, `.*Debug.*Only.*`
+  reachable from the public surface.
+
+### Dependency hygiene
+
+- Dismiss every open Dependabot alert with a documented rationale.
+- Re-submit the dependency graph:
+  `gh workflow run build.yml --ref main` (the build job re-runs
+  `submit-gradle`).
+- Verify the GitHub Insights > Dependencies view shows the expected resolved
+  versions (including build-classpath forces).
+
+### Integration coverage
+
+Not covered by default PR CI; must be driven manually or by an opt-in workflow.
+
+**Instrumented tests on a real device.**
+
+```
+./gradlew :kiosk-ops-sdk:connectedDebugAndroidTest
+```
+
+Target API 33 and API 34 emulators (minSdk + latest). Every test passes;
+re-run once to confirm non-flakiness.
+
+**Fuzz run against the release candidate.**
+
+```
+./gradlew :kiosk-ops-sdk:fuzzTest
+```
+
+Dedicated pass on the exact commit we will tag. No crash artifacts; no
+regressions from the previous release.
+
+## Blocking on tag push
+
+**Cosign signature verification.**
+
+After the release workflow publishes on `v*.*.*`:
+
+```
+cosign verify-blob \
+  --signature kiosk-ops-sdk-release.aar.sig \
+  --certificate kiosk-ops-sdk-release.aar.pem \
+  --certificate-identity-regexp 'https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  kiosk-ops-sdk-release.aar
+```
+
+Confirms the artifact on Maven Central matches what GitHub Actions produced.
+
+## Post-tag drills
+
+Run in the window between tag push and public announcement. Document any
+findings in the GitHub Release notes.
+
+### Host-app smoke on a clean device
+
+- Wipe a test device.
+- Install sample-app `assembleRelease` built from the tag.
+- Confirm SDK init succeeds; first heartbeat lands in the audit trail.
+- Exercise each `dataRights.*` call with a `DataRightsAuthorizer` returning
+  `Authorized`; verify the audit trail records the decision.
+- Export diagnostics. Open the ZIP. Confirm `manifest.json`,
+  `health_snapshot.json`, `queue/quarantined_summaries.json`, `truncation.txt`
+  where applicable; no payloads included.
+
+### Pin rotation drill
+
+- Deploy sample-app against a mock server presenting certificate A, with pin A
+  configured.
+- Push a managed-config update carrying pin B. Restart. Traffic against cert A
+  fails with a `certificate_pin_failure` audit entry and a
+  `KioskOpsErrorListener.TransportError` callback.
+- Switch mock server to certificate B. Traffic succeeds.
+
+### Database corruption recovery
+
+- On a rooted device or emulator (`adb root`), overwrite a page of
+  `kiosk_ops_queue.db` or the encrypted variant with random bytes.
+- Restart the app. Verify:
+  - `KioskOpsErrorListener.StorageError` fires with the expected message.
+  - Audit trail records `database_corruption_detected`.
+  - Subsequent `enqueue` calls succeed against the recreated DB.
+
+### Process-kill mid-sync
+
+- Enqueue 100 events against a mock server that delays responses by 30 seconds.
+- Call `syncOnce()`. When the server sees the request body, before it responds,
+  `adb shell am force-stop` the app.
+- Relaunch. Verify:
+  - `reconcileStaleSending` (shipped in v1.2.0) flips `SENDING` rows back to
+    `PENDING` on init.
+  - Next `syncOnce()` drains the backlog.
+
+### In-place upgrade from prior minor
+
+- Install sample-app built against the previous minor (e.g., 1.1.0). Enqueue a
+  handful of events. Trigger one heartbeat.
+- Without clearing app data, upgrade to the new version.
+- Confirm:
+  - Queue DB opens without a schema-migration crash.
+  - `InstallSecret` migrated from legacy plaintext to Keystore-wrapped format
+    (for the 1.2.0 upgrade specifically).
+  - Sync path drains the backlog.
+  - `KioskOpsErrorListener` receives no `StorageError` or unexpected errors.
+
+## Gaps tracked for future releases
+
+Items on the v1.3.0 roadmap that would tighten this document further:
+
+- Backward-compatibility fixture: a pinned copy of the sample-app at the previous
+  minor that can be built against the current AAR. Makes the in-place upgrade
+  drill mechanical.
+- Mock-server infrastructure (MockWebServer wrapper with cert rotation). Makes
+  the pin rotation drill scripted.
+- Performance benchmarks (androidx.benchmark). Catches silent regressions in
+  `heartbeat`, `enqueue`, and the sync batch-send hot path.
+- `scripts/pre-release-verify.sh` extended to drive a Robolectric-based
+  subset of the corruption and process-kill drills for CI-time verification.
+
+## History
+
+| Version | First verified against | Notes |
+|---|---|---|
+| 1.2.0 | This document's first use | Checklist formalised as part of the release itself. |

--- a/scripts/pre-release-verify.sh
+++ b/scripts/pre-release-verify.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Pre-release verification for KioskOps SDK.
+#
+# Runs the shell-automatable subset of docs/RELEASE_VERIFICATION.md. Intended to be
+# executed on a clean checkout at the release candidate commit before pushing the
+# `v*.*.*` tag. Fails fast on any gate.
+#
+# Covered:
+#   Code correctness (unit tests, apiCheck, detekt, sample-app, kover, dokka).
+#   Release artifact verification (publishToMavenLocal, SBOM inspection, AAR surface).
+#   Fresh fuzz pass against the release candidate.
+#
+# Not covered (manual; see docs/RELEASE_VERIFICATION.md):
+#   Instrumented tests on a real device.
+#   Cosign verification after tag push.
+#   Integrator-perspective drills (host-app smoke, pin rotation, corruption
+#   recovery, process-kill mid-sync, in-place upgrade).
+
+set -euo pipefail
+
+die() { printf 'pre-release-verify: %s\n' "$*" >&2; exit 1; }
+log() { printf '\n==> %s\n' "$*"; }
+
+# Resolve repo root from the script location.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+VERSION="$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)"
+[ -n "$VERSION" ] || die "could not read VERSION_NAME from gradle.properties"
+log "Verifying release candidate $VERSION at $(git rev-parse --short HEAD)"
+
+# --- code correctness ------------------------------------------------------
+
+log "Running gradle verification tasks"
+./gradlew \
+  :kiosk-ops-sdk:testDebugUnitTest \
+  :kiosk-ops-sdk:apiCheck \
+  :kiosk-ops-sdk:detekt \
+  :sample-app:assembleDebug \
+  :sample-app:assembleRelease \
+  :kiosk-ops-sdk:koverVerifyDebug \
+  :kiosk-ops-sdk:dokkaGeneratePublicationHtml \
+  --no-daemon
+
+# --- artifact verification -------------------------------------------------
+
+log "Publishing to Maven Local for artifact inspection"
+./gradlew :kiosk-ops-sdk:publishToMavenLocal --no-daemon
+
+MAVEN_DIR="$HOME/.m2/repository/com/sarastarquant/kioskops/kiosk-ops-sdk/$VERSION"
+[ -d "$MAVEN_DIR" ] || die "expected artifacts under $MAVEN_DIR but directory missing"
+
+AAR="$MAVEN_DIR/kiosk-ops-sdk-$VERSION.aar"
+POM="$MAVEN_DIR/kiosk-ops-sdk-$VERSION.pom"
+SOURCES="$MAVEN_DIR/kiosk-ops-sdk-$VERSION-sources.jar"
+JAVADOC="$MAVEN_DIR/kiosk-ops-sdk-$VERSION-javadoc.jar"
+
+for f in "$AAR" "$POM" "$SOURCES" "$JAVADOC"; do
+  [ -s "$f" ] || die "missing or empty artifact: $f"
+done
+
+log "POM references verification"
+grep -q 'github.com/sara-star-quant' "$POM" \
+  || die "POM does not reference the expected repo owner"
+grep -q 'github.com/pzverkov' "$POM" \
+  && die "POM references legacy repo owner; run the org-rename sweep"
+true
+
+log "Sources jar carries .kt files"
+unzip -l "$SOURCES" | grep -qE '\.kt$' \
+  || die "sources jar has no .kt files"
+
+log "AAR surface audit"
+AAR_TMP="$(mktemp -d)"
+trap 'rm -rf "$AAR_TMP"' EXIT
+unzip -q "$AAR" -d "$AAR_TMP"
+unzip -q "$AAR_TMP/classes.jar" -d "$AAR_TMP/classes"
+
+if find "$AAR_TMP/classes" -path '*net/zetetic/database/sqlcipher/*.class' | grep -q .; then
+  die "AAR bundles SQLCipher classes; SQLCipher should be compileOnly"
+fi
+if find "$AAR_TMP/classes" -path '*com/appmattus/*' | grep -q .; then
+  die "AAR bundles appmattus classes; should have been removed in 1.2"
+fi
+if find "$AAR_TMP/classes" -name '*Test*.class' -o -name '*Fake*.class' -o -name '*Mock*.class' | grep -q .; then
+  die "AAR contains test-support classes"
+fi
+
+[ -s "$AAR_TMP/AndroidManifest.xml" ] || die "AAR missing AndroidManifest.xml"
+grep -q 'androidx.startup.InitializationProvider' "$AAR_TMP/AndroidManifest.xml" \
+  || die "AAR manifest missing androidx.startup provider"
+if grep -qE '<activity\b' "$AAR_TMP/AndroidManifest.xml"; then
+  die "AAR manifest declares <activity>; library should not ship activities"
+fi
+
+[ -s "$AAR_TMP/proguard.txt" ] || die "AAR missing consumer proguard rules"
+
+# --- SBOM audit (best-effort; skip if cyclonedxBom task not configured) ----
+
+if ./gradlew tasks --all --no-daemon 2>/dev/null | grep -q cyclonedxBom; then
+  log "SBOM generation and content check"
+  ./gradlew :kiosk-ops-sdk:cyclonedxBom --no-daemon
+  BOM="$REPO_ROOT/kiosk-ops-sdk/build/reports/bom.json"
+  [ -s "$BOM" ] || die "SBOM generation produced no bom.json"
+
+  if command -v jq >/dev/null 2>&1; then
+    if jq -e '.components[] | select(.purl | test("pkg:maven/org\\.bouncycastle/"))' "$BOM" >/dev/null; then
+      die "SBOM lists BouncyCastle as a runtime dep; should be build-classpath only"
+    fi
+    if jq -e '.components[] | select(.purl | test("pkg:maven/com\\.appmattus\\.certificatetransparency/"))' "$BOM" >/dev/null; then
+      die "SBOM lists appmattus certificatetransparency; should be absent in 1.2"
+    fi
+  else
+    printf 'pre-release-verify: jq not installed; SBOM content audit skipped\n' >&2
+  fi
+else
+  printf 'pre-release-verify: cyclonedxBom task not available; SBOM step skipped\n' >&2
+fi
+
+# --- fresh fuzz pass -------------------------------------------------------
+
+log "Fresh fuzz pass (Jazzer-backed fuzzTest)"
+./gradlew :kiosk-ops-sdk:fuzzTest --no-daemon
+
+log "All automated release gates passed for $VERSION."
+log "Manual gates remaining (see docs/RELEASE_VERIFICATION.md): instrumented"
+log "tests on device, cosign verification on tag push, integrator drills."


### PR DESCRIPTION
Codifies the pre-tag gate that was previously informal. Document is the source of truth; script automates the shell-runnable subset.

## docs/RELEASE_VERIFICATION.md
Three sections by stage:

- **Blocking before tag push**: code correctness, release artifact verification, dependency hygiene, integration coverage (instrumented + fresh fuzz).
- **Blocking on tag push**: cosign signature verification of the published artifact.
- **Post-tag drills**: host-app smoke on a clean device, pin rotation, database corruption recovery, process-kill mid-sync, in-place upgrade from prior minor.

## scripts/pre-release-verify.sh
Automates gradle verification + `publishToMavenLocal` inspection + AAR surface audit + SBOM content check + fuzz pass. Fails fast.

Checks performed:
- POM references verification.
- Sources jar contains `.kt` files.
- AAR classes contain no SQLCipher, no appmattus, no test-support classes.
- AndroidManifest declares no `<activity>`, exactly one `androidx.startup` provider.
- Consumer ProGuard rules present.
- SBOM lists no BouncyCastle runtime dep, no appmattus.

## ROADMAP v1.3 additions
Release verification infrastructure section listing items not yet automatable:
- Backward-compat fixture (pinned prior-minor sample-app).
- Mock-server harness with cert rotation and body-delay.
- Performance benchmarks via androidx.benchmark.
- Robolectric-based drills for corruption and process-kill.

## CHANGELOG tightening
Removes the "Known issues" block calling the heartbeat test flaky. PR #109 merged to main and fixed the race; the note is now stale.

## Local verification
`bash -n scripts/pre-release-verify.sh` passes.