### PR TITLE
Fix pre-release-verify script paths and grep pipeline

### DIFF
--- a/scripts/pre-release-verify.sh
+++ b/scripts/pre-release-verify.sh
@@ -46,16 +46,18 @@ log "Running gradle verification tasks"
 
 # --- artifact verification -------------------------------------------------
 
-log "Publishing to Maven Local for artifact inspection"
-./gradlew :kiosk-ops-sdk:publishToMavenLocal --no-daemon
+log "Producing release artifacts in-tree (bypasses the publishing pipeline to skip signing)"
+./gradlew \
+  :kiosk-ops-sdk:bundleReleaseAar \
+  :kiosk-ops-sdk:sourceReleaseJar \
+  :kiosk-ops-sdk:javaDocReleaseJar \
+  :kiosk-ops-sdk:generatePomFileForMavenPublication \
+  --no-daemon
 
-MAVEN_DIR="$HOME/.m2/repository/com/sarastarquant/kioskops/kiosk-ops-sdk/$VERSION"
-[ -d "$MAVEN_DIR" ] || die "expected artifacts under $MAVEN_DIR but directory missing"
-
-AAR="$MAVEN_DIR/kiosk-ops-sdk-$VERSION.aar"
-POM="$MAVEN_DIR/kiosk-ops-sdk-$VERSION.pom"
-SOURCES="$MAVEN_DIR/kiosk-ops-sdk-$VERSION-sources.jar"
-JAVADOC="$MAVEN_DIR/kiosk-ops-sdk-$VERSION-javadoc.jar"
+AAR="$REPO_ROOT/kiosk-ops-sdk/build/outputs/aar/kiosk-ops-sdk-release.aar"
+POM="$REPO_ROOT/kiosk-ops-sdk/build/publications/maven/pom-default.xml"
+SOURCES="$REPO_ROOT/kiosk-ops-sdk/build/intermediates/source_jar/release/release-sources.jar"
+JAVADOC="$REPO_ROOT/kiosk-ops-sdk/build/intermediates/java_doc_jar/release/release-javadoc.jar"
 
 for f in "$AAR" "$POM" "$SOURCES" "$JAVADOC"; do
   [ -s "$f" ] || die "missing or empty artifact: $f"
@@ -69,8 +71,10 @@ grep -q 'github.com/pzverkov' "$POM" \
 true
 
 log "Sources jar carries .kt files"
-unzip -l "$SOURCES" | grep -qE '\.kt$' \
-  || die "sources jar has no .kt files"
+# Counting instead of `grep -q`: grep terminates early on first match and closes
+# the pipe, which triggers SIGPIPE on unzip; `set -o pipefail` would then fail.
+kt_count="$(unzip -l "$SOURCES" | grep -cE '\.kt$' || true)"
+[ "$kt_count" -gt 0 ] || die "sources jar has no .kt files"
 
 log "AAR surface audit"
 AAR_TMP="$(mktemp -d)"
@@ -97,27 +101,17 @@ fi
 
 [ -s "$AAR_TMP/proguard.txt" ] || die "AAR missing consumer proguard rules"
 
-# --- SBOM audit (best-effort; skip if cyclonedxBom task not configured) ----
+# --- SBOM generation -------------------------------------------------------
+# The AAR surface audit above is the ground truth for what ships at runtime.
+# CycloneDX reports the full dependency graph including build classpath, which
+# makes purl-based scope filtering unreliable across plugin versions. Here we
+# only verify the SBOM generates and is non-empty; any "what ships" assertion
+# belongs in the AAR audit.
 
-if ./gradlew tasks --all --no-daemon 2>/dev/null | grep -q cyclonedxBom; then
-  log "SBOM generation and content check"
-  ./gradlew :kiosk-ops-sdk:cyclonedxBom --no-daemon
-  BOM="$REPO_ROOT/kiosk-ops-sdk/build/reports/bom.json"
-  [ -s "$BOM" ] || die "SBOM generation produced no bom.json"
-
-  if command -v jq >/dev/null 2>&1; then
-    if jq -e '.components[] | select(.purl | test("pkg:maven/org\\.bouncycastle/"))' "$BOM" >/dev/null; then
-      die "SBOM lists BouncyCastle as a runtime dep; should be build-classpath only"
-    fi
-    if jq -e '.components[] | select(.purl | test("pkg:maven/com\\.appmattus\\.certificatetransparency/"))' "$BOM" >/dev/null; then
-      die "SBOM lists appmattus certificatetransparency; should be absent in 1.2"
-    fi
-  else
-    printf 'pre-release-verify: jq not installed; SBOM content audit skipped\n' >&2
-  fi
-else
-  printf 'pre-release-verify: cyclonedxBom task not available; SBOM step skipped\n' >&2
-fi
+log "SBOM generation"
+./gradlew :kiosk-ops-sdk:cyclonedxBom --no-daemon
+BOM="$REPO_ROOT/kiosk-ops-sdk/build/reports/cyclonedx/bom.json"
+[ -s "$BOM" ] || die "SBOM generation produced no bom.json"
 
 # --- fresh fuzz pass -------------------------------------------------------
 


### PR DESCRIPTION
Four corrections surfaced running the script against main at 51caf18:

1. Switch artifact source from `publishToMavenLocal` to direct tasks (`bundleReleaseAar`, `sourceReleaseJar`, `javaDocReleaseJar`, `generatePomFileForMavenPublication`). `publishToMavenLocal` trips on `signAllPublications()` without signing keys; signing runs in the release workflow at tag time.

2. Update artifact paths to match AGP layout: `build/outputs/aar`, `build/intermediates/source_jar/release`, `build/intermediates/java_doc_jar/release`, `build/publications/maven`.

3. Switch `unzip -l | grep -qE` to a counting pattern. `grep -q` closes the pipe on first match; `set -o pipefail` turns that SIGPIPE into a failure.

4. SBOM path corrected to `build/reports/cyclonedx/bom.json`. Dropped the BouncyCastle/appmattus purl assertion since CycloneDX 3.x includes the full dependency graph (build classpath too). The AAR surface audit earlier in the script is the ground truth for what ships at runtime.

## Verified
Script now passes end-to-end against main; all automated gates green for 1.2.0.