### PR TITLE
Fix cosign sign-blob under v3 bundle format and Dokka Pages concurrency

### DIFF
--- a/.github/workflows/dokka-pages.yml
+++ b/.github/workflows/dokka-pages.yml
@@ -12,6 +12,13 @@ on:
     tags: [ "v*.*.*" ]
   workflow_dispatch: {}
 
+# GitHub Pages allows only one active deployment per environment. A push-to-main plus
+# a tag push arriving seconds apart would otherwise race and the second deploy fails.
+# Cancel the older in-flight deploy when a newer one queues.
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,11 @@ jobs:
         run: |
           cd kiosk-ops-sdk/build/outputs/aar
           for file in *.aar; do
-            cosign sign-blob --yes "$file" \
+            # --new-bundle-format=false keeps the legacy .sig / .pem outputs referenced
+            # by the verify-blob snippet in the release summary. cosign v3.x defaults to
+            # the bundle format; leaving --output-signature/--output-certificate effective
+            # requires the explicit opt-out.
+            cosign sign-blob --yes --new-bundle-format=false "$file" \
               --output-signature "${file}.sig" \
               --output-certificate "${file}.pem"
           done


### PR DESCRIPTION
Two fixes surfaced by the v1.2.0 tag push.

## release.yml: cosign 3.0.5 bundle-format default
The `sign-blob` step failed with:
> `Error: signing kiosk-ops-sdk-release.aar: create bundle file: open : no such file or directory`

cosign 3.x (installed via `cosign-installer` v4.1.1) defaults to `--new-bundle-format=true`. That makes `--output-signature` and `--output-certificate` no-ops and expects `--bundle <path>` instead. Since the release summary still documents the verify flow with `--signature` and `--certificate`, keeping the legacy `.sig` / `.pem` outputs is the minimum-change path: pass `--new-bundle-format=false` explicitly. Full migration to `--bundle` is a separate refactor.

## dokka-pages.yml: concurrent Pages deploys
A push-to-main plus a tag push arriving within seconds of each other triggered two parallel deploys to the `github-pages` environment. GitHub Pages rejects concurrent deploys per environment; the second deploy failed.

Added:
```yaml
concurrency:
  group: github-pages
  cancel-in-progress: true
```

A newer deploy now supersedes an older in-flight one.

## Not verified end-to-end
Neither fix can be validated without re-running against the tag. Once merged, rerun `release.yml` (workflow_dispatch) and push a no-op commit to retrigger `dokka-pages.yml`.