### PR TITLE
Pin cosign 2.5.3 in release.yml to unblock sign-blob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,16 +59,17 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          # Pinned to cosign 2.x to keep --output-signature / --output-certificate
+          # effective. cosign 3.x defaults to the bundle format and rejects the legacy
+          # flag set; migrating to --bundle is tracked for v1.3.
+          cosign-release: v2.5.3
 
       - name: Sign release artifacts with Sigstore
         run: |
           cd kiosk-ops-sdk/build/outputs/aar
           for file in *.aar; do
-            # --new-bundle-format=false keeps the legacy .sig / .pem outputs referenced
-            # by the verify-blob snippet in the release summary. cosign v3.x defaults to
-            # the bundle format; leaving --output-signature/--output-certificate effective
-            # requires the explicit opt-out.
-            cosign sign-blob --yes --new-bundle-format=false "$file" \
+            cosign sign-blob --yes "$file" \
               --output-signature "${file}.sig" \
               --output-certificate "${file}.pem"
           done

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -448,6 +448,10 @@ earned after 1.2. Deferred from the original v1.2 scope.
 - [ ] Detekt baseline-rot CI guard
 
 ### Release verification infrastructure
+- [ ] Migrate `release.yml` cosign invocation from the legacy
+  `--output-signature` / `--output-certificate` to the `--bundle` form.
+  Pinned to cosign 2.5.3 as of 1.2.0; cosign 2.x will eventually EOL.
+  Update the `verify-blob` snippet in the release summary to match.
 - [ ] Backward-compatibility fixture: pinned copy of sample-app at the
   previous minor, buildable against the current AAR. Makes
   `docs/RELEASE_VERIFICATION.md` IP5 mechanical.


### PR DESCRIPTION
cosign 3.0.5 rejected both the bare legacy flag pair and the `--new-bundle-format=false` opt-out that #112 added:

> `Error: must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config`

cosign 2.x accepts `--output-signature` / `--output-certificate` unchanged. Pinning `sigstore/cosign-installer` input `cosign-release: v2.5.3` and reverting the sign-blob call to the pre-new-bundle form. Release summary `verify-blob` snippet stays valid.

ROADMAP v1.3 gains a line to migrate the invocation to `--bundle` form before cosign 2.x reaches end-of-life.