### PR TITLE
Fix HealthCheckAndErrorListenerTest missing lifecycle reset in setUp

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,6 @@
-// Pin transitive plugin-classpath dependencies with open CVEs.
-// These ship in AGP/lint/layoutlib and other plugin classpaths; they never
-// reach the published SDK AAR but flag in dependency-review because
-// Dependabot attributes them to settings.gradle.kts (pluginManagement).
-// bcprov/bcpkix < 1.84: GHSA-c3fc-8qff-9hwx, GHSA-wg6q-6289-32hp
-// bcpg  1.80: Bouncy Castle Uncontrolled Resource Consumption (high)
-// plexus-utils < 3.6.1: GHSA-6fmv-xxpf-w3cw directory traversal
+// Pin transitive dependencies with open CVEs across all configurations.
+// bcprov/bcpkix/bcutil/bcpg < 1.84: GHSA-c3fc-8qff-9hwx, GHSA-wg6q-6289-32hp, GHSA-p93r-85wp-75v3
+// plexus-utils < 3.6.1: GHSA-6fmv-xxpf-w3cw
 buildscript {
   configurations.classpath {
     resolutionStrategy.force(
@@ -28,4 +24,15 @@ plugins {
 
 apiValidation {
   ignoredProjects += listOf("sample-app")
+}
+
+subprojects {
+  configurations.configureEach {
+    resolutionStrategy.force(
+      "org.bouncycastle:bcprov-jdk18on:1.84",
+      "org.bouncycastle:bcpkix-jdk18on:1.84",
+      "org.bouncycastle:bcutil-jdk18on:1.84",
+      "org.bouncycastle:bcpg-jdk18on:1.84",
+    )
+  }
 }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/HealthCheckAndErrorListenerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/HealthCheckAndErrorListenerTest.kt
@@ -25,6 +25,8 @@ class HealthCheckAndErrorListenerTest {
 
   @Before
   fun setUp() {
+    KioskOpsSdk.resetForTesting()
+    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
     ctx = ApplicationProvider.getApplicationContext()
     ctx.deleteDatabase("kiosk_ops_queue.db")
     ctx.deleteDatabase("kioskops_audit.db")


### PR DESCRIPTION
## Summary

- Add `resetForTesting()` and `skipLifecycleObserverRegistrationForTesting = true` to `HealthCheckAndErrorListenerTest.setUp()`, matching every other test class in the suite; prevents a leaked lifecycle observer from firing stray heartbeats that cause order-dependent test failures.
- Extend Bouncy Castle 1.84 force-resolution from buildscript classpath to all subproject configurations; the previous scope left test/build configurations resolving to 1.80.2, which tripped the dependency-review check (GHSA-p93r-85wp-75v3).
