### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-05-28
+
+Build toolchain upgrade. No SDK API changes.
+
+### Changed
+- Android Gradle Plugin 8.10.1 -> 9.1.1
+- Gradle 8.11.1 -> 9.3.1
+- JDK toolchain 17 -> 21
+- Migrated to AGP 9's built-in Kotlin; removed `kotlin-android` plugin
+- Bouncy Castle force-resolution extended to all subproject configurations (1.84)
+
+### Removed
+- binary-compatibility-validator (discontinued, incompatible with AGP 9 built-in Kotlin); `.api` file retained
+
+### Fixed
+- Flaky `heartbeat reason is reflected in healthCheck` test caused by leaked lifecycle observer
+
+### Dependencies
+- detekt 1.23.7 -> 1.23.8
+- cyclonedx 3.2.3 -> 3.2.4
+- foojay-resolver-convention 0.9.0 -> 1.0.0
+- codeql-action 4.35.2 -> 4.35.3
+- gradle/actions 4.4.1 -> 6.1.0
+- actions/setup-java 4.7.1 -> 5.2.0
+- actions/deploy-pages 4.0.5 -> 5.0.0
+- actions/upload-pages-artifact 3.0.1 -> 5.0.0
+
 ## [1.2.0] - 2026-04-20
 
 Reliability and security hardening release. Closes the v1.0 audit follow-ups,
@@ -813,6 +840,7 @@ Initial release of KioskOps SDK for Android Enterprise.
 - Java 17+
 - Kotlin 2.1+
 
+[1.2.1]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v1.2.1
 [1.2.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v1.2.0
 [1.1.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v1.1.0
 [1.0.0]: https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.1")
 }
 ```
 
@@ -60,7 +60,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.1")
 }
 ```
 
@@ -76,7 +76,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.2.0")
+    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.2.1")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ kotlin.code.style=official
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 # SDK Version
-VERSION_NAME=1.2.0
+VERSION_NAME=1.2.1

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
     minSdk = 33
     targetSdk = 36
     versionCode = 3
-    versionName = "1.2.0"
+    versionName = "1.2.1"
   }
 
   buildTypes {


### PR DESCRIPTION
## Summary

- Bump VERSION_NAME to 1.2.1.
- Update installation snippets in README.
- Update sample-app versionName.
- Add CHANGELOG entry covering AGP 9 migration, Gradle 9, JDK 21, dependency updates, flaky test fix, and BCV removal.
