### PR TITLE
Remove reflection from sample-app error listener handling

### DIFF
--- a/sample-app/src/main/java/com/sarastarquant/kioskops/sample/BatchEnqueueActivity.kt
+++ b/sample-app/src/main/java/com/sarastarquant/kioskops/sample/BatchEnqueueActivity.kt
@@ -28,7 +28,10 @@ import kotlinx.coroutines.launch
  */
 class BatchEnqueueActivity : Activity() {
   private val scope = MainScope()
-  private val errors = mutableListOf<String>()
+  // CopyOnWriteArrayList: the error listener may fire on a background thread while
+  // the main thread reads the list to render results.
+  private val errors = java.util.concurrent.CopyOnWriteArrayList<String>()
+  private val sdk = KioskOpsSdk.get()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -40,17 +43,12 @@ class BatchEnqueueActivity : Activity() {
     val queueDepthText = findViewById<TextView>(R.id.queueDepthText)
     val errorText = findViewById<TextView>(R.id.errorText)
 
-    val sdk = KioskOpsSdk.get()
-
-    // Capture errors during the batch run.
-    val previousListener = sdk.javaClass.getDeclaredField("errorListener").let { field ->
-      field.isAccessible = true
-      field.get(sdk) as? KioskOpsErrorListener
-    }
-
+    // Capture errors during the batch run, chaining to the app-wide listener so
+    // SampleApp's logging stays active for the activity's lifetime.
+    val appListener = (application as SampleApp).errorLogListener
     sdk.setErrorListener(KioskOpsErrorListener { error ->
       errors.add(error.message)
-      previousListener?.onError(error)
+      appListener.onError(error)
     })
 
     btnStartBatch.setOnClickListener {
@@ -105,6 +103,8 @@ class BatchEnqueueActivity : Activity() {
 
   override fun onDestroy() {
     super.onDestroy()
+    // Drop the activity-capturing listener so the SDK does not retain this Activity.
+    sdk.setErrorListener((application as SampleApp).errorLogListener)
     scope.cancel()
   }
 }

--- a/sample-app/src/main/java/com/sarastarquant/kioskops/sample/SampleApp.kt
+++ b/sample-app/src/main/java/com/sarastarquant/kioskops/sample/SampleApp.kt
@@ -10,6 +10,12 @@ import com.sarastarquant.kioskops.sdk.sync.SyncPolicy
 import com.sarastarquant.kioskops.sdk.transport.AuthProvider
 
 class SampleApp : Application() {
+  // App-wide error listener, held so other components (e.g. BatchEnqueueActivity)
+  // can chain to it without reaching into SDK internals.
+  val errorLogListener = KioskOpsErrorListener { error ->
+    Log.w("KioskOps", "SDK error: ${error.message}", error.cause)
+  }
+
   override fun onCreate() {
     super.onCreate()
 
@@ -38,9 +44,7 @@ class SampleApp : Application() {
 
     // v0.7.0: Error listener for non-fatal SDK operational errors.
     // Fires on sync failures, crypto errors, storage errors; not on expected rejections.
-    sdk.setErrorListener(KioskOpsErrorListener { error ->
-      Log.w("KioskOps", "SDK error: ${error.message}", error.cause)
-    })
+    sdk.setErrorListener(errorLogListener)
 
     // v1.0.0: Data rights authorization callback.
     // cuiDefaults requires authorization before export/delete/wipe operations.


### PR DESCRIPTION
## Summary

`BatchEnqueueActivity` read the SDK's private `errorListener` field via reflection (`getDeclaredField("errorListener")`) to chain to the app-wide listener it was about to replace. A reference app should not model private-internals access for integrators, and the call would break with a silent `NoSuchFieldException` if a future SDK version renamed the field or tightened the consumer keep rule.

This change moves the fix to the consumer side, where it belongs. The SDK's error listener is single-replaceable and write-only by design (consistent with `setDiagnosticsUploader`, `setPiiDetector`, `setAnomalyDetector`, `setDataRightsAuthorizer`); adding a public getter or multi-listener API to serve a sample would erode that convention. Instead, `SampleApp` exposes the listener it owns as a property, and the activity chains to it directly.

## Changes

- `SampleApp`: extract the inline error-logging lambda into a public `errorLogListener` property and register that instance; behavior is unchanged.
- `BatchEnqueueActivity`: replace the reflection block with a read of `(application as SampleApp).errorLogListener`.
- `BatchEnqueueActivity`: restore the app listener in `onDestroy`; the prior code installed a capturing listener but never removed it, so the SDK retained the destroyed activity.
- `BatchEnqueueActivity`: back the capture list with `CopyOnWriteArrayList`; `setErrorListener`'s contract allows background-thread invocation while the main thread renders results.

No SDK module changes; no public API or behavior change for integrators.

## Verification

- `grep -rn getDeclaredField sample-app/src` returns nothing.
- `./gradlew :sample-app:compileDebugKotlin :sample-app:compileReleaseKotlin` succeeds; the release variant confirms the minified path compiles.
