### PR TITLE
pin netty to 4.1.135.Final to close UTP test-classpath CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Pin `io.netty` to 4.1.135.Final across all subproject configurations. netty
+  is a transitive of `grpc-netty` in the Android Unified Test Platform (test
+  execution only); it is absent from `releaseRuntimeClasspath` and never ships
+  in the AAR. The pin closes GHSA-3qp7-7mw8-wx86 and GHSA-x4gw-5cx5-pgmh
+  (netty-handler, high) and GHSA-5x3r-wrvg-rp6q and GHSA-c2gf-v879-257j
+  (netty-codec-http2, medium).
+
 ## [1.2.1] - 2026-05-28
 
 Build toolchain upgrade. No SDK API changes.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 // Pin transitive dependencies with open CVEs across all configurations.
 // bcprov/bcpkix/bcutil/bcpg < 1.84: GHSA-c3fc-8qff-9hwx, GHSA-wg6q-6289-32hp, GHSA-p93r-85wp-75v3
 // plexus-utils < 3.6.1: GHSA-6fmv-xxpf-w3cw
+// netty < 4.1.135: GHSA-3qp7-7mw8-wx86, GHSA-x4gw-5cx5-pgmh, GHSA-5x3r-wrvg-rp6q, GHSA-c2gf-v879-257j
 buildscript {
   configurations.classpath {
     resolutionStrategy.force(
@@ -28,5 +29,13 @@ subprojects {
       "org.bouncycastle:bcutil-jdk18on:1.84",
       "org.bouncycastle:bcpg-jdk18on:1.84",
     )
+    // netty arrives only via grpc-netty in the Android Unified Test Platform
+    // configurations (test-only; absent from releaseRuntimeClasspath, never in the AAR).
+    // Pin the whole io.netty family so the modules stay version-aligned.
+    resolutionStrategy.eachDependency {
+      if (requested.group == "io.netty") {
+        useVersion("4.1.135.Final")
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Pins `io.netty` to 4.1.135.Final across all subproject configurations, closing four open Dependabot alerts. No SDK API or runtime change; the affected netty only exists in the instrumented-test toolchain.

## Root cause

netty is a transitive of `io.grpc:grpc-netty` (1.57.2 / 1.69.1), which is itself pulled by the Android Unified Test Platform (UTP); UTP uses gRPC to talk to the emulator. The resolved modules sat at 4.1.93.Final / 4.1.110.Final, below the 4.1.135.Final fix.

Verified during planning via dependency resolution:
- netty's entire footprint is two configurations, `unified-test-platform-core` and `unified-test-platform-android-test-plugin-host-emulator-control`, in both `:kiosk-ops-sdk` and `:sample-app`; no other configuration contains it.
- netty is absent from `:kiosk-ops-sdk:releaseRuntimeClasspath`, so it never ships in the published AAR and cannot reach a consumer; the SDK's transport is OkHttp.

Dependabot cannot fix this on its own; there is no direct netty declaration to bump.

## Change

`build.gradle.kts`, in the existing `subprojects { configurations.configureEach { ... } }` block that already force-pins Bouncy Castle, add a whole-family rule:

```kotlin
resolutionStrategy.eachDependency {
  if (requested.group == "io.netty") {
    useVersion("4.1.135.Final")
  }
}
```

A family rule rather than a per-module `force(...)` list because UTP pulls ~11 netty modules that must stay version-aligned; pinning the group rules out skew and covers any module UTP adds later. The top-of-file CVE comment and `CHANGELOG.md` (new `[Unreleased]` Security entry) are updated to record the four advisories.

## Advisories closed

- GHSA-3qp7-7mw8-wx86 (netty-handler, high; IPv6 subnet filter bypass)
- GHSA-x4gw-5cx5-pgmh (netty-handler, high; SNI handler 16 MiB pre-allocation DoS)
- GHSA-5x3r-wrvg-rp6q (netty-codec-http2, medium; MAX_CONCURRENT_STREAMS not enforced)
- GHSA-c2gf-v879-257j (netty-codec-http2, medium; ByteBuf reference-count leak)

The alerts auto-resolve once the "Automatic Dependency Submission (Gradle)" workflow re-runs on `main` and re-resolves the graph at 4.1.135.Final.

## Verification

- `dependencyInsight --configuration unified-test-platform-core --dependency io.netty:netty-handler` reports `4.1.135.Final (selected by rule)`; the whole netty subtree resolves to 4.1.135.Final.
- `dependencyInsight --configuration releaseRuntimeClasspath --dependency io.netty` reports no match; netty stays out of the shipped artifact.
- `./gradlew build` passes (197 tasks). The UTP emulator job runs on `main` only, so test execution with the pinned netty is exercised post-merge.
