### PR TITLE
bump version to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.2] - 2026-06-12
+
+Build toolchain upgrade and dependency security hygiene. No SDK API changes.
 
 ### Security
 
-- Pin `io.netty` to 4.1.135.Final across all subproject configurations. netty
+- Pinned `io.netty` to 4.1.135.Final across all subproject configurations. netty
   is a transitive of `grpc-netty` in the Android Unified Test Platform (test
   execution only); it is absent from `releaseRuntimeClasspath` and never ships
-  in the AAR. The pin closes GHSA-3qp7-7mw8-wx86 and GHSA-x4gw-5cx5-pgmh
-  (netty-handler, high) and GHSA-5x3r-wrvg-rp6q and GHSA-c2gf-v879-257j
-  (netty-codec-http2, medium).
+  in the AAR. Closes GHSA-3qp7-7mw8-wx86 and GHSA-x4gw-5cx5-pgmh (netty-handler,
+  high) and GHSA-5x3r-wrvg-rp6q and GHSA-c2gf-v879-257j (netty-codec-http2, medium).
+
+### Changed
+
+- Android Gradle Plugin 9.1.1 -> 9.2.1
+- Gradle 9.3.1 -> 9.5.1
+- Migrated `publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)` to the no-arg
+  `publishToMavenCentral()`; Central Portal is the default and the `SonatypeHost`
+  overload was removed in vanniktech maven-publish 0.36.0. Same publish target.
+- Sample app error-listener wiring no longer uses reflection.
+
+### Dependencies
+
+- kotlin 2.3.20 -> 2.3.21
+- kotlinx-coroutines 1.10.2 -> 1.11.0
+- junit5 6.0.3 -> 6.1.0
+- vanniktech maven-publish 0.30.0 -> 0.36.0
+- actions/checkout 6.0.2 -> 6.0.3
+- actions/dependency-review-action 4.9.0 -> 5.0.0
+- codeql-action 4.35.3 -> 4.36.2
+- sigstore/cosign-installer 4.1.1 -> 4.1.2
 
 ## [1.2.1] - 2026-05-28
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.1")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.2")
 }
 ```
 
@@ -60,7 +60,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.1")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.2")
 }
 ```
 
@@ -76,7 +76,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.2.1")
+    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.2.2")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ kotlin.code.style=official
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 # SDK Version
-VERSION_NAME=1.2.1
+VERSION_NAME=1.2.2

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
     minSdk = 33
     targetSdk = 36
     versionCode = 3
-    versionName = "1.2.1"
+    versionName = "1.2.2"
   }
 
   buildTypes {


### PR DESCRIPTION
## Summary

Cuts v1.2.2, a build-toolchain and dependency-security release. No SDK API or runtime changes; the published surface is identical to v1.2.1. This draws a release line around the toolchain bumps and the netty CVE pin already merged to `main`.

## What's in this release

Version bump (`gradle.properties`, `sample-app` versionName, three README install snippets) and the finalized `[1.2.2]` CHANGELOG section covering the changes that landed on `main` since v1.2.1:

- **Security:** `io.netty` pinned to 4.1.135.Final, closing four Dependabot alerts (GHSA-3qp7-7mw8-wx86, GHSA-x4gw-5cx5-pgmh, GHSA-5x3r-wrvg-rp6q, GHSA-c2gf-v879-257j). netty is a test-only transitive of the Android Unified Test Platform; it never ships in the AAR.
- **Toolchain:** AGP 9.1.1 -> 9.2.1; Gradle 9.3.1 -> 9.5.1; Kotlin 2.3.20 -> 2.3.21; coroutines 1.10.2 -> 1.11.0; junit5 6.0.3 -> 6.1.0; vanniktech maven-publish 0.30.0 -> 0.36.0 (migrated to no-arg `publishToMavenCentral()`).
- **CI:** checkout 6.0.3, dependency-review-action 5.0.0, codeql-action 4.36.2, cosign-installer 4.1.2.

## Scope

Patch only. The v1.3.0 "Distribution" milestone (BOM artifact, version-catalog snippet, LTS policy, full SCT verification) is deliberately deferred to a separate effort; none of it is on `main`.

## Verification

- `./gradlew build` passes on `main` with all the above merged (197 tasks).
- The four netty alerts already show closed after the dependency-graph resubmission.
- No changes under `kiosk-ops-sdk/src` or the `.api` file; the published API is unchanged from v1.2.1.

## Release steps after merge

1. Tag the merge commit `v1.2.2` and push the tag.
2. Run the `Release` workflow (workflow_dispatch) with `tag=v1.2.2` to publish the signed artifacts.
