### PR TITLE
add kioskops-bom platform module for coordinated versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
-          ./gradlew :kiosk-ops-sdk:publishAndReleaseToMavenCentral --no-configuration-cache -PVERSION_NAME="$VERSION" || {
+          ./gradlew :kiosk-ops-sdk:publishAndReleaseToMavenCentral :kioskops-bom:publishAndReleaseToMavenCentral --no-configuration-cache -PVERSION_NAME="$VERSION" || {
             echo "::warning::Maven Central publish failed. Continuing."
           }
         env:
@@ -98,7 +98,7 @@ jobs:
 
       - name: Publish to GitHub Packages
         run: |
-          ./gradlew :kiosk-ops-sdk:publishMavenPublicationToGitHubPackagesRepository --no-configuration-cache -PVERSION_NAME="$VERSION" || {
+          ./gradlew :kiosk-ops-sdk:publishMavenPublicationToGitHubPackagesRepository :kioskops-bom:publishMavenPublicationToGitHubPackagesRepository --no-configuration-cache -PVERSION_NAME="$VERSION" || {
             echo "::warning::GitHub Packages publish failed (version may already exist). Continuing."
           }
         env:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ dependencies {
 }
 ```
 
+Optionally pin the version once via the BOM (`kioskops-bom`); see
+[Integration](docs/INTEGRATION.md#optional-bom-for-coordinated-versions) for the BOM and
+Gradle version-catalog snippets.
+
 ### Option B: GitHub Packages
 
 ```kotlin

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -23,6 +23,38 @@ See the [README Installation](../README.md#installation) section for the current
 release version, GitHub Packages coordinates, and the JitPack fallback. In-repo
 consumers (sample-app) continue to use `implementation(project(":kiosk-ops-sdk"))`.
 
+### Optional: BOM for coordinated versions
+
+A Bill of Materials (`com.sarastarquant.kioskops:kioskops-bom`) lets you pin the
+KioskOps version once and omit it on the artifact:
+
+```kotlin
+dependencies {
+  implementation(platform("com.sarastarquant.kioskops:kioskops-bom:<latest>"))
+  implementation("com.sarastarquant.kioskops:kiosk-ops-sdk")
+}
+```
+
+### Optional: Gradle version catalog
+
+To keep the coordinate in `gradle/libs.versions.toml`:
+
+```toml
+[versions]
+kioskops = "<latest>"
+
+[libraries]
+kioskops-bom = { module = "com.sarastarquant.kioskops:kioskops-bom", version.ref = "kioskops" }
+kioskops-sdk = { module = "com.sarastarquant.kioskops:kiosk-ops-sdk" }
+```
+
+```kotlin
+dependencies {
+  implementation(platform(libs.kioskops.bom))
+  implementation(libs.kioskops.sdk)
+}
+```
+
 ---
 
 ## 2) Initialize in your Application

--- a/kioskops-bom/build.gradle.kts
+++ b/kioskops-bom/build.gradle.kts
@@ -1,0 +1,70 @@
+// Bill of Materials: lets consumers align KioskOps artifact versions in one place.
+// Today it constrains the single published library; the module exists so multi-artifact
+// coordination (planned splits) does not require a consumer-facing breaking change later.
+plugins {
+  `java-platform`
+  alias(libs.plugins.maven.publish)
+}
+
+val sdkVersion = findProperty("VERSION_NAME")?.toString() ?: "0.1.0-SNAPSHOT"
+
+dependencies {
+  constraints {
+    api("com.sarastarquant.kioskops:kiosk-ops-sdk:$sdkVersion")
+  }
+}
+
+// Maven Central publishing via Vanniktech plugin (POM-only platform artifact)
+mavenPublishing {
+  publishToMavenCentral()
+  signAllPublications()
+
+  coordinates(
+    groupId = "com.sarastarquant.kioskops",
+    artifactId = "kioskops-bom",
+    version = sdkVersion,
+  )
+
+  pom {
+    name.set("KioskOps SDK BOM")
+    description.set("Bill of Materials for coordinated versioning of KioskOps SDK artifacts")
+    url.set("https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise")
+
+    licenses {
+      license {
+        name.set("Business Source License 1.1")
+        url.set("https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/blob/main/LICENSE")
+      }
+    }
+
+    developers {
+      developer {
+        id.set("pzverkov")
+        name.set("Petro Zverkov")
+        organization.set("Sara Star Quant LLC")
+      }
+    }
+
+    scm {
+      url.set("https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise")
+      connection.set("scm:git:git://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise.git")
+      developerConnection.set("scm:git:ssh://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise.git")
+    }
+  }
+}
+
+// GitHub Packages repository (secondary distribution)
+afterEvaluate {
+  publishing {
+    repositories {
+      maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise")
+        credentials {
+          username = System.getenv("GITHUB_ACTOR") ?: findProperty("gpr.user")?.toString()
+          password = System.getenv("GITHUB_TOKEN") ?: findProperty("gpr.token")?.toString()
+        }
+      }
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,4 +19,4 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "KioskOpsSdk"
-include(":kiosk-ops-sdk", ":sample-app")
+include(":kiosk-ops-sdk", ":sample-app", ":kioskops-bom")


### PR DESCRIPTION
## Summary

Adds a `kioskops-bom` Maven BOM so consumers can pin the KioskOps version once and omit it on the artifact. First of the v1.3.0 "Distribution" workstream.

## Change

- New `kioskops-bom` `java-platform` module. Its POM is `packaging=pom` with a `<dependencyManagement>` constraint on `kiosk-ops-sdk` at `VERSION_NAME`, so the two always release in lockstep. The module carries its own minimal `mavenPublishing` config (Central Portal + signing) and the GitHub Packages secondary repo, mirroring the SDK module's POM metadata.
- `settings.gradle.kts` includes `:kioskops-bom`.
- `release.yml` publishes the BOM alongside the SDK to Maven Central and GitHub Packages.
- `docs/INTEGRATION.md` and `README.md` document BOM usage and a Gradle version-catalog snippet.

The module exists now (with a single constraint) so a future multi-artifact split needs no consumer-facing breaking change.

## Verification

- `:kioskops-bom:generatePomFileForMavenPublication` produces the expected POM: `com.sarastarquant.kioskops:kioskops-bom`, `packaging=pom`, `<dependencyManagement>` -> `kiosk-ops-sdk:1.2.2`.
- `./gradlew build` green with the new module.
- Local `publishToMavenLocal` signing is skipped by design (no local signatory; same as the SDK module); the in-memory GPG key path runs in `release.yml`.

## Notes

- Consumer usage: `implementation(platform("com.sarastarquant.kioskops:kioskops-bom:<v>"))` then `implementation("com.sarastarquant.kioskops:kiosk-ops-sdk")`.
- The `release.yml` touch here will rebase cleanly under the later release-infra PR.
