### PR TITLE
migrate release signing to cosign bundles and add coverage and baseline guards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,16 @@ jobs:
             lintDebug \
             :kiosk-ops-sdk:assembleRelease
 
+      - name: Detekt baseline rot check
+        run: |
+          cp config/detekt/baseline.xml /tmp/baseline.committed.xml
+          ./gradlew :kiosk-ops-sdk:detektBaseline
+          if ! diff -u /tmp/baseline.committed.xml config/detekt/baseline.xml; then
+            echo "::error::Detekt baseline has stale entries (suppressions no longer triggered). Run './gradlew :kiosk-ops-sdk:detektBaseline' and commit the result."
+            cp /tmp/baseline.committed.xml config/detekt/baseline.xml
+            exit 1
+          fi
+
       - name: Generate docs and SBOM
         run: |
           ./gradlew \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,21 +57,35 @@ jobs:
       - name: Run tests
         run: ./gradlew :kiosk-ops-sdk:testDebugUnitTest
 
+      - name: Generate coverage report
+        run: |
+          ./gradlew :kiosk-ops-sdk:koverXmlReportDebug :kiosk-ops-sdk:koverHtmlReportDebug
+          COV="N/A"
+          REPORT="kiosk-ops-sdk/build/reports/kover/reportDebug.xml"
+          if [ -f "$REPORT" ]; then
+            COV=$(python3 -c "
+          import xml.etree.ElementTree as ET
+          t=ET.parse('$REPORT').getroot(); m=c=0
+          for p in t.findall('.//package'):
+            for x in p.findall('counter'):
+              if x.get('type')=='LINE': m+=int(x.get('missed',0)); c+=int(x.get('covered',0))
+          print(f'{int(c*100/(m+c))}%' if (m+c)>0 else 'N/A')")
+          fi
+          echo "COVERAGE=$COV" >> "$GITHUB_ENV"
+          (cd kiosk-ops-sdk/build/reports/kover && zip -qr "$GITHUB_WORKSPACE/kiosk-ops-sdk-coverage.zip" html)
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          # Pinned to cosign 2.x to keep --output-signature / --output-certificate
-          # effective. cosign 3.x defaults to the bundle format and rejects the legacy
-          # flag set; migrating to --bundle is tracked for v1.3.
-          cosign-release: v2.5.3
+          # cosign 3.x uses the Sigstore bundle format (sig + cert + Rekor entry in one
+          # file). Release assets ship a single .bundle per artifact instead of .sig/.pem.
+          cosign-release: v3.1.1
 
       - name: Sign release artifacts with Sigstore
         run: |
           cd kiosk-ops-sdk/build/outputs/aar
           for file in *.aar; do
-            cosign sign-blob --yes "$file" \
-              --output-signature "${file}.sig" \
-              --output-certificate "${file}.pem"
+            cosign sign-blob --yes "$file" --bundle "${file}.bundle"
           done
 
       - name: Attest build provenance (SLSA)
@@ -116,8 +130,10 @@ jobs:
           else
             echo "Release ${VERSION}" > release_notes.md
           fi
+          printf '\n\nLine coverage: %s (full report attached as kiosk-ops-sdk-coverage.zip).\n' "$COVERAGE" >> release_notes.md
         env:
           INPUT_VERSION: ${{ steps.version.outputs.VERSION }}
+          COVERAGE: ${{ env.COVERAGE }}
 
       - name: Create GitHub Release
         run: |
@@ -126,8 +142,8 @@ jobs:
             --notes-file release_notes.md \
             --latest \
             kiosk-ops-sdk/build/outputs/aar/*.aar \
-            kiosk-ops-sdk/build/outputs/aar/*.sig \
-            kiosk-ops-sdk/build/outputs/aar/*.pem
+            kiosk-ops-sdk/build/outputs/aar/*.bundle \
+            kiosk-ops-sdk-coverage.zip
         env:
           TAG: ${{ steps.version.outputs.TAG }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -144,8 +160,7 @@ jobs:
           echo "### Signature Verification" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "cosign verify-blob kiosk-ops-sdk-release.aar \\" >> $GITHUB_STEP_SUMMARY
-          echo "  --signature kiosk-ops-sdk-release.aar.sig \\" >> $GITHUB_STEP_SUMMARY
-          echo "  --certificate kiosk-ops-sdk-release.aar.pem \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --bundle kiosk-ops-sdk-release.aar.bundle \\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate-identity-regexp 'https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise' \\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,7 @@ cd KioskOps-SDK-Android-Enterprise
 | Run fuzz tests | `./gradlew :kiosk-ops-sdk:fuzzTest` |
 | Run lint | `./gradlew lintDebug` |
 | Run Detekt (static analysis) | `./gradlew :kiosk-ops-sdk:detekt` |
-| Check API compatibility | `./gradlew apiCheck` |
-| Update API dump | `./gradlew apiDump` |
+| Regenerate Detekt baseline | `./gradlew :kiosk-ops-sdk:detektBaseline` |
 | Generate API docs | `./gradlew :kiosk-ops-sdk:dokkaGeneratePublicationHtml` |
 | Generate coverage report | `./gradlew :kiosk-ops-sdk:koverHtmlReportDebug` |
 | Run all checks | `./gradlew check` |
@@ -83,11 +82,12 @@ Report: `kiosk-ops-sdk/build/reports/lint-results-debug.html`
 
 ### PR Requirements
 
-- All CI checks must pass (tests, lint, Detekt, apiCheck, Dokka)
-- `./gradlew apiCheck` must pass (no unintended public API changes)
-- If public API changes are intentional, run `./gradlew apiDump` and commit the updated `.api` file
+- All CI checks must pass (tests, lint, Detekt, Dokka)
 - Unit test coverage for new code
 - No new lint or Detekt warnings
+- If a refactor removes a suppressed finding, regenerate the Detekt baseline
+  (`./gradlew :kiosk-ops-sdk:detektBaseline`) and commit it; the baseline-rot CI check
+  fails on stale entries
 - Update documentation if needed
 
 ## Reporting Issues

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -7,7 +7,6 @@
     <ID>CyclomaticComplexMethod:DataRightsManager.kt$DataRightsManager$suspend fun exportUserData(userId: String): DataExportResult</ID>
     <ID>CyclomaticComplexMethod:JsonSchemaValidator.kt$JsonSchemaValidator$private fun matchesType(element: JsonElement, expected: String): Boolean</ID>
     <ID>CyclomaticComplexMethod:JsonSchemaValidator.kt$JsonSchemaValidator$private fun validateElement( element: JsonElement, schema: JsonElement, path: String, errors: MutableList&lt;String>, )</ID>
-    <ID>CyclomaticComplexMethod:KioskOpsSdk.kt$KioskOpsSdk$suspend fun enqueueDetailed( type: String, payloadJson: String, stableEventId: String? = null, idempotencyKeyOverride: String? = null, userId: String? = null, ): com.sarastarquant.kioskops.sdk.queue.EnqueueResult</ID>
     <ID>CyclomaticComplexMethod:StatisticalAnomalyDetector.kt$StatisticalAnomalyDetector$override fun analyze(eventType: String, payloadJson: String): AnomalyResult</ID>
     <ID>CyclomaticComplexMethod:SyncEngine.kt$SyncEngine$suspend fun flushOnce(): TransportResult&lt;SyncOnceResult></ID>
     <ID>EmptyFunctionBlock:GeofenceTransitionListener.kt$GeofenceTransitionAdapter${}</ID>
@@ -20,7 +19,6 @@
     <ID>EmptyFunctionBlock:SyncEngineTest.kt$SyncEngineTest.&lt;no name provided>${}</ID>
     <ID>ImplicitDefaultLocale:SpanContext.kt$SpanContext$String.format("%02x", traceFlags)</ID>
     <ID>LongMethod:JsonSchemaValidator.kt$JsonSchemaValidator$private fun validateElement( element: JsonElement, schema: JsonElement, path: String, errors: MutableList&lt;String>, )</ID>
-    <ID>LongMethod:KioskOpsSdk.kt$KioskOpsSdk$suspend fun enqueueDetailed( type: String, payloadJson: String, stableEventId: String? = null, idempotencyKeyOverride: String? = null, userId: String? = null, ): com.sarastarquant.kioskops.sdk.queue.EnqueueResult</ID>
     <ID>LongMethod:RemoteConfigManager.kt$RemoteConfigManager$suspend fun processConfigBundle( bundle: Bundle, source: ConfigSource, ): ConfigUpdateResult</ID>
     <ID>LongMethod:SyncEngine.kt$SyncEngine$suspend fun flushOnce(): TransportResult&lt;SyncOnceResult></ID>
     <ID>LongParameterList:QueueRepository.kt$QueueRepository$( type: String, payloadJson: String, bytes: ByteArray, nowOverrideMs: Long?, cfg: KioskOpsConfig, stableEventId: String?, idempotencyKeyOverride: String?, droppedOldest: Int, userId: String? = null, dataClassification: String? = null, anomalyScore: Float? = null, )</ID>
@@ -33,11 +31,8 @@
     <ID>NestedBlockDepth:DataRightsManager.kt$DataRightsManager$suspend fun exportAllLocalData(): DataExportResult</ID>
     <ID>NestedBlockDepth:DataRightsManager.kt$DataRightsManager$suspend fun exportUserData(userId: String): DataExportResult</ID>
     <ID>NestedBlockDepth:JsonSchemaValidator.kt$JsonSchemaValidator$private fun validateElement( element: JsonElement, schema: JsonElement, path: String, errors: MutableList&lt;String>, )</ID>
-    <ID>NestedBlockDepth:KioskOpsSdk.kt$KioskOpsSdk$suspend fun enqueueDetailed( type: String, payloadJson: String, stableEventId: String? = null, idempotencyKeyOverride: String? = null, userId: String? = null, ): com.sarastarquant.kioskops.sdk.queue.EnqueueResult</ID>
     <ID>NestedBlockDepth:QueueRepository.kt$QueueRepository$suspend fun enqueue( type: String, payloadJson: String, cfg: KioskOpsConfig, stableEventId: String? = null, idempotencyKeyOverride: String? = null, userId: String? = null, dataClassification: String? = null, anomalyScore: Float? = null, ): EnqueueResult</ID>
     <ID>NestedBlockDepth:StatisticalAnomalyDetector.kt$StatisticalAnomalyDetector$override fun analyze(eventType: String, payloadJson: String): AnomalyResult</ID>
-    <ID>ProtectedMemberInFinalClass:GeofenceManager.kt$GeofenceManager$protected fun registerGeofences(regions: List&lt;GeofenceRegion>)</ID>
-    <ID>ProtectedMemberInFinalClass:GeofenceManager.kt$GeofenceManager$protected fun unregisterGeofences()</ID>
     <ID>ReturnCount:BatteryCollector.kt$BatteryCollector$private fun computeTimeRemaining(batteryManager: BatteryManager?, status: Int): Int?</ID>
     <ID>ReturnCount:CertificatePinningInterceptor.kt$CertificatePinningInterceptor$private fun matchesHostname(pattern: String, hostname: String): Boolean</ID>
     <ID>ReturnCount:DiagnosticsSchedulerWorker.kt$DiagnosticsSchedulerWorker$override suspend fun doWork(): Result</ID>
@@ -46,7 +41,6 @@
     <ID>ReturnCount:GeofenceManager.kt$GeofenceManager$@RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION) suspend fun startMonitoring(): GeofenceStartResult</ID>
     <ID>ReturnCount:KeyAttestationReporter.kt$KeyAttestationReporter$fun generateAttestationChallengeResponse( alias: String, challenge: ByteArray, ): AttestationResponse?</ID>
     <ID>ReturnCount:KeystoreAttestationProvider.kt$KeystoreAttestationProvider$override fun getAttestationBlob(): ByteArray?</ID>
-    <ID>ReturnCount:KioskOpsSdk.kt$KioskOpsSdk$suspend fun enqueueDetailed( type: String, payloadJson: String, stableEventId: String? = null, idempotencyKeyOverride: String? = null, userId: String? = null, ): com.sarastarquant.kioskops.sdk.queue.EnqueueResult</ID>
     <ID>ReturnCount:KioskOpsTracer.kt$KioskOpsSpanBuilder$override fun startSpan(): Span</ID>
     <ID>ReturnCount:KioskOpsTracer.kt$KioskOpsSpanBuilder$private fun getContextFromCorrelation(): SpanContext?</ID>
     <ID>ReturnCount:PersistentAuditTrail.kt$PersistentAuditTrail$suspend fun verifyChainIntegrity( fromTs: Long? = null, toTs: Long? = null, ): ChainVerificationResult</ID>
@@ -60,7 +54,6 @@
     <ID>SwallowedException:KeyMetadataStore.kt$KeyMetadataStore$e: Exception</ID>
     <ID>SwallowedException:KeystoreAttestationProvider.kt$KeystoreAttestationProvider$e: Exception</ID>
     <ID>SwallowedException:KeystoreAttestationProvider.kt$KeystoreAttestationProvider.Companion$e: Exception</ID>
-    <ID>SwallowedException:MtlsClientBuilder.kt$MtlsClientBuilder$e: Exception</ID>
     <ID>SwallowedException:VersionedCryptoProvider.kt$VersionedCryptoProvider$e: Exception</ID>
     <ID>TooGenericExceptionCaught:CorrelatedOperation.kt$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:DataRightsManager.kt$DataRightsManager$e: Exception</ID>
@@ -88,7 +81,6 @@
     <ID>UnusedPrivateProperty:ChainVerificationResultTest.kt$ChainVerificationResultTest$val signatureInvalid: ChainVerificationResult = ChainVerificationResult.SignatureInvalid("id", 0, "reason")</ID>
     <ID>UnusedPrivateProperty:HardwareAcceleratedDetector.kt$HardwareAcceleratedDetector$private val mlTimeoutMs: Long = 200L</ID>
     <ID>UnusedPrivateProperty:HardwareAcceleratedDetector.kt$HardwareAcceleratedDetector$private val modelHash: String? = null</ID>
-    <ID>UnusedPrivateProperty:HardwareAcceleratedDetector.kt$HardwareAcceleratedDetector$private val nnapiAvailable: Boolean by lazy { Build.VERSION.SDK_INT >= 27 &amp;&amp; checkNnapiAvailability() }</ID>
     <ID>UnusedPrivateProperty:KeyAttestationReporter.kt$KeyAttestationReporter$private val context: Context</ID>
     <ID>UnusedPrivateProperty:KeystoreAttestationProvider.kt$KeystoreAttestationProvider$private val context: Context</ID>
     <ID>UnusedPrivateProperty:KioskOpsTracer.kt$KioskOpsTracer$private val instrumentationVersion: String?</ID>

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -119,7 +119,18 @@ regressions from the previous release.
 
 **Cosign signature verification.**
 
-After the release workflow publishes on `v*.*.*`:
+After the release workflow publishes on `v*.*.*` (v1.3.0 and later ship a single
+`.bundle` per artifact; requires cosign 3.x):
+
+```
+cosign verify-blob \
+  --bundle kiosk-ops-sdk-release.aar.bundle \
+  --certificate-identity-regexp 'https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  kiosk-ops-sdk-release.aar
+```
+
+For v1.2.x and earlier (separate `.sig` + `.pem`, cosign 2.x):
 
 ```
 cosign verify-blob \

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ androidxTestCore = "1.7.0"
 androidxTestRunner = "1.7.0"
 androidxTestRules = "1.7.0"
 androidxTestExtJunit = "1.3.0"
-bcv = "0.18.1"
 dokka = "2.2.0"
 detekt = "1.23.8"
 kover = "0.9.8"
@@ -68,7 +67,6 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "bcv" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/scripts/pre-release-verify.sh
+++ b/scripts/pre-release-verify.sh
@@ -36,7 +36,6 @@ log "Verifying release candidate $VERSION at $(git rev-parse --short HEAD)"
 log "Running gradle verification tasks"
 ./gradlew \
   :kiosk-ops-sdk:testDebugUnitTest \
-  :kiosk-ops-sdk:apiCheck \
   :kiosk-ops-sdk:detekt \
   :sample-app:assembleDebug \
   :sample-app:assembleRelease \


### PR DESCRIPTION
## Summary

Release-verification infrastructure for v1.3.0: cosign bundle signing, per-tag coverage, a detekt baseline-rot guard, and removal of a dead API-check step.

## Changes

- **cosign `--bundle` migration** (`release.yml`): cosign 2.5.3 -> 3.1.1. Signing emits one `.bundle` per artifact (sig + cert + Rekor entry) instead of `.sig`+`.pem`; release assets and the verify snippet follow. `docs/RELEASE_VERIFICATION.md` documents the new command and keeps the legacy snippet for verifying v1.2.x and earlier.
- **Kover coverage per release tag** (`release.yml`): generates the report, attaches `kiosk-ops-sdk-coverage.zip` to the GitHub Release, and prints line coverage in the notes. Satisfies CII Silver `test_coverage_documented`.
- **Detekt baseline-rot guard** (`build.yml`): regenerates the baseline in CI and fails if it differs from the committed one (stale suppressions). This already caught 8 stale entries; the baseline is cleaned in this PR. Regeneration is documented in `CONTRIBUTING.md`.
- **Remove dead `apiCheck`**: binary-compatibility-validator was dropped in v1.2.1, but `pre-release-verify.sh` and `CONTRIBUTING.md` still referenced `apiCheck`/`apiDump` and the catalog kept orphan `bcv` entries. Removed. See note below.

## Note: API-compatibility enforcement gap

The SDK has had no enforced public-API guard since 1.2.0 (BCV was AGP-9-incompatible), despite the v1.0 API-freeze commitment. This PR only removes the dead references. Re-establishing enforcement (AGP-9-compatible validator or Metalava) is tracked for v1.4.

## Verification

- Both workflows parse as valid YAML.
- `./gradlew build` green.
- Baseline-rot guard passes against the cleaned baseline; detekt still green with the 8 stale entries removed.
- `release.yml` BOM publish lines from the prior PR are preserved.
