### PR TITLE
deduplicate high-security presets, pretty-print config, fix lifecycle observer leak

### DIFF
--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsConfig.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsConfig.kt
@@ -82,24 +82,32 @@ data class KioskOpsConfig @JvmOverloads constructor(
    * is still present in [equals] / [hashCode] for reactive-config diffing.
    * @since 1.1.0
    */
-  override fun toString(): String = "KioskOpsConfig(" +
-    "baseUrl=$baseUrl, locationId=$locationId, kioskEnabled=$kioskEnabled, " +
-    "syncIntervalMinutes=$syncIntervalMinutes, " +
-    "adminExitPin=${if (adminExitPin == null) "null" else "***"}, " +
-    "securityPolicy=$securityPolicy, retentionPolicy=$retentionPolicy, " +
-    "telemetryPolicy=$telemetryPolicy, queueLimits=$queueLimits, " +
-    "idempotencyConfig=$idempotencyConfig, syncPolicy=$syncPolicy, " +
-    "transportSecurityPolicy=$transportSecurityPolicy, " +
-    "remoteConfigPolicy=$remoteConfigPolicy, " +
-    "diagnosticsSchedulePolicy=$diagnosticsSchedulePolicy, " +
-    "observabilityPolicy=$observabilityPolicy, geofencePolicy=$geofencePolicy, " +
-    "policyProfiles=$policyProfiles, validationPolicy=$validationPolicy, " +
-    "piiPolicy=$piiPolicy, fieldEncryptionPolicy=$fieldEncryptionPolicy, " +
-    "dataClassificationPolicy=$dataClassificationPolicy, " +
-    "anomalyPolicy=$anomalyPolicy, " +
-    "databaseEncryptionPolicy=$databaseEncryptionPolicy, " +
-    "requireDataRightsAuthorization=$requireDataRightsAuthorization" +
-    ")"
+  override fun toString(): String = listOf(
+    "baseUrl=$baseUrl",
+    "locationId=$locationId",
+    "kioskEnabled=$kioskEnabled",
+    "syncIntervalMinutes=$syncIntervalMinutes",
+    "adminExitPin=${if (adminExitPin == null) "null" else "***"}",
+    "securityPolicy=$securityPolicy",
+    "retentionPolicy=$retentionPolicy",
+    "telemetryPolicy=$telemetryPolicy",
+    "queueLimits=$queueLimits",
+    "idempotencyConfig=$idempotencyConfig",
+    "syncPolicy=$syncPolicy",
+    "transportSecurityPolicy=$transportSecurityPolicy",
+    "remoteConfigPolicy=$remoteConfigPolicy",
+    "diagnosticsSchedulePolicy=$diagnosticsSchedulePolicy",
+    "observabilityPolicy=$observabilityPolicy",
+    "geofencePolicy=$geofencePolicy",
+    "policyProfiles=$policyProfiles",
+    "validationPolicy=$validationPolicy",
+    "piiPolicy=$piiPolicy",
+    "fieldEncryptionPolicy=$fieldEncryptionPolicy",
+    "dataClassificationPolicy=$dataClassificationPolicy",
+    "anomalyPolicy=$anomalyPolicy",
+    "databaseEncryptionPolicy=$databaseEncryptionPolicy",
+    "requireDataRightsAuthorization=$requireDataRightsAuthorization",
+  ).joinToString(separator = "\n  ", prefix = "KioskOpsConfig(\n  ", postfix = "\n)")
 
   companion object {
     /**
@@ -149,22 +157,38 @@ data class KioskOpsConfig @JvmOverloads constructor(
      */
     fun fedRampDefaults(baseUrl: String, locationId: String): KioskOpsConfig {
       warnIfHttpsWithoutTransportSecurity("fedRampDefaults", baseUrl)
-      return KioskOpsConfig(
-        baseUrl = baseUrl,
-        locationId = locationId,
-        kioskEnabled = true,
-        securityPolicy = SecurityPolicy.highSecurityDefaults(),
-        retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
-          retainAuditDays = 365,
-          minimumAuditRetentionDays = 365,
-        ),
-        validationPolicy = ValidationPolicy.strictDefaults(),
-        piiPolicy = PiiPolicy.rejectDefaults(),
-        fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
-        dataClassificationPolicy = DataClassificationPolicy.enabledDefaults(),
-        anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
-      )
+      return highSecurityBase(baseUrl, locationId)
     }
+
+    /**
+     * Shared high-security preset shape: strict validation, field encryption, anomaly
+     * detection, signed audit, and 365-day audit retention. Presets pass their deltas
+     * (PII action, classification, database encryption, data-rights authorization).
+     */
+    private fun highSecurityBase(
+      baseUrl: String,
+      locationId: String,
+      piiPolicy: PiiPolicy = PiiPolicy.rejectDefaults(),
+      dataClassificationPolicy: DataClassificationPolicy = DataClassificationPolicy.enabledDefaults(),
+      databaseEncryptionPolicy: DatabaseEncryptionPolicy = DatabaseEncryptionPolicy.disabledDefaults(),
+      requireDataRightsAuthorization: Boolean = false,
+    ): KioskOpsConfig = KioskOpsConfig(
+      baseUrl = baseUrl,
+      locationId = locationId,
+      kioskEnabled = true,
+      securityPolicy = SecurityPolicy.highSecurityDefaults(),
+      retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
+        retainAuditDays = 365,
+        minimumAuditRetentionDays = 365,
+      ),
+      validationPolicy = ValidationPolicy.strictDefaults(),
+      piiPolicy = piiPolicy,
+      fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
+      dataClassificationPolicy = dataClassificationPolicy,
+      anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
+      databaseEncryptionPolicy = databaseEncryptionPolicy,
+      requireDataRightsAuthorization = requireDataRightsAuthorization,
+    )
 
     /**
      * GDPR-compliant defaults.
@@ -199,22 +223,12 @@ data class KioskOpsConfig @JvmOverloads constructor(
      */
     fun cuiDefaults(baseUrl: String, locationId: String): KioskOpsConfig {
       warnIfHttpsWithoutTransportSecurity("cuiDefaults", baseUrl)
-      return KioskOpsConfig(
-        baseUrl = baseUrl,
-        locationId = locationId,
-        kioskEnabled = true,
-        securityPolicy = SecurityPolicy.highSecurityDefaults(),
-        retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
-          retainAuditDays = 365,
-          minimumAuditRetentionDays = 365,
-        ),
-        validationPolicy = ValidationPolicy.strictDefaults(),
-        piiPolicy = PiiPolicy.rejectDefaults(),
-        fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
+      return highSecurityBase(
+        baseUrl,
+        locationId,
         dataClassificationPolicy = DataClassificationPolicy.enabledDefaults().copy(
           defaultClassification = DataClassification.CONFIDENTIAL,
         ),
-        anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
         databaseEncryptionPolicy = DatabaseEncryptionPolicy.enabledDefaults(),
         requireDataRightsAuthorization = true,
       )
@@ -234,22 +248,12 @@ data class KioskOpsConfig @JvmOverloads constructor(
      */
     fun cjisDefaults(baseUrl: String, locationId: String): KioskOpsConfig {
       warnIfHttpsWithoutTransportSecurity("cjisDefaults", baseUrl)
-      return KioskOpsConfig(
-        baseUrl = baseUrl,
-        locationId = locationId,
-        kioskEnabled = true,
-        securityPolicy = SecurityPolicy.highSecurityDefaults(),
-        retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
-          retainAuditDays = 365,
-          minimumAuditRetentionDays = 365,
-        ),
-        validationPolicy = ValidationPolicy.strictDefaults(),
-        piiPolicy = PiiPolicy.rejectDefaults(),
-        fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
+      return highSecurityBase(
+        baseUrl,
+        locationId,
         dataClassificationPolicy = DataClassificationPolicy.enabledDefaults().copy(
           defaultClassification = DataClassification.CONFIDENTIAL,
         ),
-        anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
         databaseEncryptionPolicy = DatabaseEncryptionPolicy.enabledDefaults(),
         requireDataRightsAuthorization = true,
       )
@@ -266,21 +270,7 @@ data class KioskOpsConfig @JvmOverloads constructor(
      */
     fun asdEssentialEightDefaults(baseUrl: String, locationId: String): KioskOpsConfig {
       warnIfHttpsWithoutTransportSecurity("asdEssentialEightDefaults", baseUrl)
-      return KioskOpsConfig(
-        baseUrl = baseUrl,
-        locationId = locationId,
-        kioskEnabled = true,
-        securityPolicy = SecurityPolicy.highSecurityDefaults(),
-        retentionPolicy = RetentionPolicy.maximalistDefaults().copy(
-          retainAuditDays = 365,
-          minimumAuditRetentionDays = 365,
-        ),
-        validationPolicy = ValidationPolicy.strictDefaults(),
-        piiPolicy = PiiPolicy.redactDefaults(),
-        fieldEncryptionPolicy = FieldEncryptionPolicy.enabledDefaults(),
-        dataClassificationPolicy = DataClassificationPolicy.enabledDefaults(),
-        anomalyPolicy = AnomalyPolicy.highSecurityDefaults(),
-      )
+      return highSecurityBase(baseUrl, locationId, piiPolicy = PiiPolicy.redactDefaults())
     }
   }
 }

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/KioskOpsSdk.kt
@@ -1292,12 +1292,10 @@ class KioskOpsSdk private constructor(
         created.queue.reconcileStaleSending(staleBefore)
       }
       created.applySchedulingFromConfig()
-      if (!skipLifecycleObserverRegistrationForTesting) {
-        com.sarastarquant.kioskops.sdk.lifecycle.SdkLifecycleObserver.register(
-          sdkProvider = { INSTANCE },
-          scope = created.javaInteropScope,
-        )
-      }
+      com.sarastarquant.kioskops.sdk.lifecycle.SdkLifecycleObserver.register(
+        sdkProvider = { INSTANCE },
+        scope = created.javaInteropScope,
+      )
       return created
     }
 
@@ -1309,17 +1307,12 @@ class KioskOpsSdk private constructor(
 
     @androidx.annotation.VisibleForTesting
     internal fun resetForTesting() {
+      // Drop the lifecycle observer before clearing INSTANCE. Robolectric shares one
+      // ProcessLifecycleOwner across test classes, so a leaked observer would fire
+      // heartbeat("app_backgrounded") on a later instance and race lastHeartbeatReason.
+      com.sarastarquant.kioskops.sdk.lifecycle.SdkLifecycleObserver.unregister()
       INSTANCE?.sdkJob?.cancel()
       INSTANCE = null
     }
-
-    // Robolectric shares a ProcessLifecycleOwner singleton across test classes. Each
-    // init() call registers a new observer; observers from prior test classes persist
-    // and fire heartbeat("app_backgrounded") on the current INSTANCE when Robolectric
-    // synthesizes onStop events. That races with tests that read lastHeartbeatReason.
-    // Production code never sets this; tests that exercise init() via Robolectric do.
-    @androidx.annotation.VisibleForTesting
-    @Volatile
-    internal var skipLifecycleObserverRegistrationForTesting: Boolean = false
   }
 }

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/lifecycle/SdkLifecycleObserver.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/lifecycle/SdkLifecycleObserver.kt
@@ -46,18 +46,35 @@ internal class SdkLifecycleObserver(
   companion object {
     private const val TAG = "KioskOpsLifecycle"
 
-    /**
-     * Register the observer with [ProcessLifecycleOwner].
-     * Safe to call from any thread; registration is posted to the main thread.
-     */
+    // The single observer currently attached to the shared ProcessLifecycleOwner.
+    // Retained so it can be removed on re-register or teardown; Robolectric shares one
+    // ProcessLifecycleOwner across test classes, so a leaked observer would fire
+    // heartbeat("app_backgrounded") on a later SDK instance.
+    private var registered: SdkLifecycleObserver? = null
+
+    /** Register the observer with [ProcessLifecycleOwner], replacing any prior one. */
     fun register(sdkProvider: () -> KioskOpsSdk?, scope: CoroutineScope) {
       @Suppress("TooGenericExceptionCaught")
       try {
+        unregister()
         val observer = SdkLifecycleObserver(sdkProvider, scope)
-        val lifecycle = ProcessLifecycleOwner.get().lifecycle
-        lifecycle.addObserver(observer)
+        ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
+        registered = observer
       } catch (e: Exception) {
         Log.w(TAG, "ProcessLifecycleOwner not available; lifecycle observer disabled", e)
+      }
+    }
+
+    /** Remove the registered observer, if any. */
+    fun unregister() {
+      val observer = registered ?: return
+      @Suppress("TooGenericExceptionCaught")
+      try {
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(observer)
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to remove lifecycle observer", e)
+      } finally {
+        registered = null
       }
     }
   }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/BlockingWrapperTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/BlockingWrapperTest.kt
@@ -53,7 +53,6 @@ class BlockingWrapperTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   @Test

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/FlowApisTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/FlowApisTest.kt
@@ -45,7 +45,6 @@ class FlowApisTest {
       ctx, Configuration.Builder().setMinimumLoggingLevel(android.util.Log.DEBUG).build()
     )
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
     KioskOpsSdk.init(
       context = ctx,
       configProvider = { testConfig },

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/HealthCheckAndErrorListenerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/HealthCheckAndErrorListenerTest.kt
@@ -26,7 +26,6 @@ class HealthCheckAndErrorListenerTest {
   @Before
   fun setUp() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
     ctx = ApplicationProvider.getApplicationContext()
     ctx.deleteDatabase("kiosk_ops_queue.db")
     ctx.deleteDatabase("kioskops_audit.db")
@@ -36,7 +35,6 @@ class HealthCheckAndErrorListenerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk(): KioskOpsSdk {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkInitTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkInitTest.kt
@@ -44,7 +44,6 @@ class KioskOpsSdkInitTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   @Test

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkIntegrationTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsSdkIntegrationTest.kt
@@ -46,7 +46,6 @@ class KioskOpsSdkIntegrationTest {
   @Before
   fun setUp() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
     ctx = ApplicationProvider.getApplicationContext()
     ctx.deleteDatabase("kiosk_ops_queue.db")
     ctx.deleteDatabase("kioskops_audit.db")

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/SdkLifecycleTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/SdkLifecycleTest.kt
@@ -42,7 +42,6 @@ class SdkLifecycleTest {
       ctx, Configuration.Builder().setMinimumLoggingLevel(android.util.Log.DEBUG).build()
     )
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   @After

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/pipeline/PipelineTestBase.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/pipeline/PipelineTestBase.kt
@@ -37,7 +37,6 @@ abstract class PipelineTestBase {
   @Before
   open fun setUp() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
     ctx = ApplicationProvider.getApplicationContext()
     ctx.deleteDatabase("kiosk_ops_queue.db")
     ctx.deleteDatabase("kioskops_audit.db")

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/DiagnosticsWorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/DiagnosticsWorkerTest.kt
@@ -52,7 +52,6 @@ class DiagnosticsWorkerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk(diagnosticsPolicy: DiagnosticsSchedulePolicy = DiagnosticsSchedulePolicy.disabledDefaults()) {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/EventSyncWorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/EventSyncWorkerTest.kt
@@ -51,7 +51,6 @@ class EventSyncWorkerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk(syncEnabled: Boolean = false) {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/SyncWorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/SyncWorkerTest.kt
@@ -50,7 +50,6 @@ class SyncWorkerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk() {

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/WorkerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/work/WorkerTest.kt
@@ -38,7 +38,6 @@ class WorkerTest {
   @After
   fun tearDown() {
     KioskOpsSdk.resetForTesting()
-    KioskOpsSdk.skipLifecycleObserverRegistrationForTesting = true
   }
 
   private fun initSdk() {


### PR DESCRIPTION
## Summary

Three behavior-preserving code-quality cleanups from the v1.3.0 plan. No public API change.

## Changes

- **Preset de-duplication** (`KioskOpsConfig.kt`): extracted a private `highSecurityBase(...)` factory for the shape shared by `fedRampDefaults`/`cuiDefaults`/`cjisDefaults`/`asdEssentialEightDefaults`. Each preset now passes only its deltas (PII action, classification, database encryption, data-rights authorization). The `base()` defaults mirror the `KioskOpsConfig` constructor defaults, so resolved configs are identical; `gdprDefaults` keeps its distinct permissive shape; the per-preset `warnIfHttpsWithoutTransportSecurity` calls are preserved.
- **`KioskOpsConfig.toString()` pretty-print**: one field per line for readable logs/diagnostics. `adminExitPin` stays redacted (`***`); `equals`/`hashCode` are untouched (PIN retained there for config diffing).
- **Lifecycle observer leak (proper test isolation)**: `SdkLifecycleObserver` now tracks the attached observer and exposes `unregister()`; `register()` replaces any prior observer; `resetForTesting()` calls `unregister()`. This is the real fix for the heartbeat/healthCheck flake (Robolectric shares one `ProcessLifecycleOwner` across test classes). The `skipLifecycleObserverRegistrationForTesting` workaround is removed, along with its 12 test call sites; registration is unconditional again.

## Verification

- `./gradlew :kiosk-ops-sdk:testDebugUnitTest` green; the previously-flaky `KioskOpsSdkIntegrationTest` passed across repeated `--rerun-tasks` runs.
- detekt clean and the new baseline-rot CI guard passes (no new findings).
- `assembleRelease` green. All changed declarations are private/internal, so the public API surface is unchanged.
