### PR TITLE
consolidate legal disclaimer into docs/LEGAL.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,11 +1,7 @@
 # Security Policy
 
-> **Important:** This document describes the security features and vulnerability
-> reporting process for KioskOps SDK. It is not security advice, and the authors
-> make no guarantees about the fitness of this software for any particular
-> security requirement. You are responsible for your own security assessments,
-> penetration testing, and compliance validation. The authors accept no liability
-> for security incidents arising from the use of this software.
+> **Important:** This document describes the vulnerability reporting process for KioskOps
+> SDK. It is not security advice; see [docs/LEGAL.md](../docs/LEGAL.md).
 
 ## Supported Versions
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,8 @@ An **enterprise-grade Android SDK** for **offline-first operational events**, **
 
 API reference: [sara-star-quant.github.io/KioskOps-SDK-Android-Enterprise](https://sara-star-quant.github.io/KioskOps-SDK-Android-Enterprise/) (auto-published from `main` and release tags).
 
-> **Disclaimer:** This SDK provides security controls and references regulatory frameworks
-> (NIST 800-53, FedRAMP, GDPR, ISO 27001) as engineering aids only. It is not legal,
-> compliance, or security advice. The authors assume no responsibility for regulatory
-> outcomes. You are solely responsible for evaluating whether this software meets your
-> organization's legal, security, and compliance requirements. Consult qualified
-> professionals before deploying in regulated environments. See [LICENSE](LICENSE) for
-> warranty and liability terms.
+> **Disclaimer:** Security controls and regulatory-framework references are engineering
+> aids only, not legal, compliance, or security advice. See [docs/LEGAL.md](docs/LEGAL.md).
 
 ## Installation
 

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -1,0 +1,21 @@
+# Legal Notice and Disclaimer
+
+This SDK provides security controls and references regulatory frameworks (including NIST
+800-53, NIST SP 800-171, FedRAMP, the CJIS Security Policy, GDPR, ISO 27001, BSI
+IT-Grundschutz, the ASD Essential Eight, HIPAA, and the Australian Privacy Act) as
+engineering aids only.
+
+Nothing in this repository - the SDK, its documentation, or the compliance mapping
+documents under `docs/compliance/` - constitutes legal, compliance, privacy, or security
+advice. The SDK has not been independently audited or certified against any standard. The
+compliance mappings are engineering references, not certifications.
+
+You are solely responsible for evaluating whether this software meets your organization's
+legal, security, and compliance requirements. Most regulatory controls require
+organizational policy, infrastructure, and host-application measures beyond the scope of an
+SDK. Conduct your own assessment with qualified legal and security professionals before
+deploying in regulated environments.
+
+The authors and contributors accept no responsibility for regulatory outcomes, security
+incidents, or compliance failures arising from the use of this software. See
+[LICENSE](../LICENSE) for warranty and liability terms.

--- a/docs/SECURITY_COMPLIANCE.md
+++ b/docs/SECURITY_COMPLIANCE.md
@@ -1,13 +1,7 @@
 # Security and Compliance
 
-> **Disclaimer:** This document references regulatory frameworks (NIST 800-53,
-> FedRAMP, GDPR, ISO 27001, BSI, HIPAA) as engineering context only. Nothing in
-> this document or the SDK constitutes legal, compliance, or security advice. The
-> SDK has not been independently audited or certified against any standard. The
-> authors and contributors accept no responsibility for regulatory outcomes,
-> security incidents, or compliance failures. You must conduct your own legal and
-> security assessments before deploying in regulated environments. Consult
-> qualified legal and security professionals for your specific situation.
+> **Disclaimer:** This document references regulatory frameworks as engineering context
+> only; it is not legal, compliance, or security advice. See [LEGAL.md](LEGAL.md).
 
 This SDK is designed for **enterprise environments** where you usually care about:
 - **data minimization** (collect/store the least possible)

--- a/docs/compliance/ASD-Essential-Eight-mapping.md
+++ b/docs/compliance/ASD-Essential-Eight-mapping.md
@@ -1,12 +1,8 @@
 # ASD Essential Eight: KioskOps SDK Control Mapping
 
-> **Disclaimer:** This document is an engineering reference only. It does not
-> constitute a compliance certification, legal advice, or security assessment.
-> The SDK has not been independently audited or assessed against the Australian
-> Signals Directorate Essential Eight Maturity Model. You must conduct your own
-> assessment with qualified professionals. The Essential Eight covers
-> organizational-level strategies; an SDK can only contribute to a subset of
-> each strategy.
+> **Disclaimer:** Engineering reference only, not a compliance certification or legal
+> advice; see [LEGAL.md](../LEGAL.md). The Essential Eight covers organizational-level
+> strategies; an SDK can only contribute to a subset of each strategy.
 
 ## Scope
 

--- a/docs/compliance/Australian-Privacy-Act-mapping.md
+++ b/docs/compliance/Australian-Privacy-Act-mapping.md
@@ -1,12 +1,9 @@
 # Australian Privacy Act 1988: KioskOps SDK Control Mapping
 
-> **Disclaimer:** This document is an engineering reference only. It does not
-> constitute a compliance certification, legal advice, or privacy assessment.
-> The SDK has not been independently audited against the Australian Privacy Act
-> 1988 or the Australian Privacy Principles (APPs). You must conduct your own
-> assessment with qualified legal and privacy professionals. The APPs impose
-> obligations on APP entities (organizations); an SDK provides technical
-> controls that support but do not fulfill these obligations.
+> **Disclaimer:** Engineering reference only, not a compliance certification or legal
+> advice; see [LEGAL.md](../LEGAL.md). The APPs impose obligations on APP entities
+> (organizations); an SDK provides technical controls that support but do not fulfill
+> these obligations.
 
 ## Scope
 

--- a/docs/compliance/BSI-IT-Grundschutz-mapping.md
+++ b/docs/compliance/BSI-IT-Grundschutz-mapping.md
@@ -1,11 +1,8 @@
 # BSI IT-Grundschutz: KioskOps SDK Control Mapping
 
-> **Disclaimer:** This document is an engineering reference only. It does not
-> constitute a compliance certification, legal advice, or security assessment.
-> The SDK has not been independently audited or certified against BSI
-> IT-Grundschutz. You must conduct your own assessment with qualified
-> professionals. IT-Grundschutz requirements are organizational-level; an SDK
-> addresses only a subset of technical controls.
+> **Disclaimer:** Engineering reference only, not a compliance certification or legal
+> advice; see [LEGAL.md](../LEGAL.md). IT-Grundschutz requirements are organizational-level;
+> an SDK addresses only a subset of technical controls.
 
 ## Scope
 

--- a/docs/compliance/CJIS-mapping.md
+++ b/docs/compliance/CJIS-mapping.md
@@ -1,12 +1,8 @@
 # CJIS Security Policy v5.9: KioskOps SDK Control Mapping
 
-> **Disclaimer:** This document is an engineering reference only. It does not
-> constitute a compliance certification, legal advice, or security assessment.
-> The SDK has not been independently audited or certified against the CJIS
-> Security Policy. You must conduct your own assessment with qualified
-> professionals before deploying in law enforcement or criminal justice
-> environments. Many CJIS requirements are organizational, procedural, or
-> infrastructure-level and cannot be addressed by an SDK alone.
+> **Disclaimer:** Engineering reference only, not a compliance certification or legal
+> advice; see [LEGAL.md](../LEGAL.md). Many CJIS requirements are organizational,
+> procedural, or infrastructure-level and cannot be addressed by an SDK alone.
 
 ## Scope
 

--- a/docs/compliance/DATA-FLOW.md
+++ b/docs/compliance/DATA-FLOW.md
@@ -1,10 +1,8 @@
 # Data Flow Reference: KioskOps SDK
 
-> **Disclaimer:** This document is an engineering reference describing the
-> SDK's data storage and transmission behavior. It does not constitute a
-> compliance certification, legal advice, or security assessment. You must
-> verify these statements against the SDK source code and conduct your own
-> assessment for your specific deployment context.
+> **Disclaimer:** Engineering reference describing the SDK's data storage and transmission
+> behavior; not a compliance certification or legal advice (see [LEGAL.md](../LEGAL.md)).
+> Verify these statements against the SDK source for your specific deployment context.
 
 ## Overview
 

--- a/docs/compliance/NIST-SP-800-171-mapping.md
+++ b/docs/compliance/NIST-SP-800-171-mapping.md
@@ -1,11 +1,8 @@
 # NIST SP 800-171 Rev 2: KioskOps SDK Control Mapping
 
-> **Disclaimer:** This document is an engineering reference only. It does not
-> constitute a compliance certification, legal advice, or security assessment.
-> The SDK has not been independently audited or certified against NIST SP
-> 800-171. You must conduct your own assessment with qualified professionals
-> before claiming compliance. Many 800-171 controls require organizational
-> policy, infrastructure, and host-application measures beyond SDK scope.
+> **Disclaimer:** Engineering reference only, not a compliance certification or legal
+> advice; see [LEGAL.md](../LEGAL.md). Many 800-171 controls require organizational policy,
+> infrastructure, and host-application measures beyond SDK scope.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Consolidates the legal/disclaimer boilerplate that was copy-pasted across 9 files into a single canonical `docs/LEGAL.md`. Each file now links to it; compliance docs keep their standard-specific caveat sentence.

## Changes

- New `docs/LEGAL.md`: the canonical disclaimer (engineering aids only; not legal/compliance/security advice; not audited/certified; user responsible for assessment; links `LICENSE`).
- Replaced the duplicated block with a one-line link in: `README.md`, `.github/SECURITY.md`, `docs/SECURITY_COMPLIANCE.md`, and the six `docs/compliance/*.md` files (NIST 800-171, CJIS, ASD Essential Eight, BSI IT-Grundschutz, Australian Privacy Act, DATA-FLOW).
- Each compliance doc retains its one standard-specific sentence (e.g., "Many CJIS requirements are organizational... and cannot be addressed by an SDK alone").

## Verification

- All `LEGAL.md` links resolve from their respective directories; `docs/LEGAL.md` -> `../LICENSE` resolves.
- No duplicated boilerplate remains outside `docs/LEGAL.md`.
- ASCII-only.
