### PR TITLE
add LTS maintenance branch policy and backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,27 @@
+name: Backport
+
+# Backports a merged PR to a maintenance branch when it carries a label of the form
+# "backport release/vX.Y.x". Maintainers add the label; this opens a backport PR against
+# that branch. Manual fallback: git checkout release/vX.Y.x && git cherry-pick <sha>.
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport to maintenance branch
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa # v4.5.2
+        with:
+          label_pattern: '^backport ([^ ]+)$'
+          pull_title: '[backport ${target_branch}] ${pull_title}'
+          pull_description: 'Automated backport of #${pull_number} to `${target_branch}`.'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,28 @@ Report: `kiosk-ops-sdk/build/reports/lint-results-debug.html`
   fails on stale entries
 - Update documentation if needed
 
+## Long-term support and backports
+
+`main` carries the current release line. Security fixes are backported to the active
+maintenance branches:
+
+| Branch | Covers | Status |
+| ------ | ------ | ------ |
+| `main` | next release | current |
+| `release/v1.2.x` | 1.2.x patches | supported |
+| `release/v1.1.x` | 1.1.x patches | supported (security only) |
+
+Maintenance branches receive security fixes only; no new features. To backport a merged
+PR, add a label of the form `backport release/v1.2.x` to it; the
+[backport workflow](.github/workflows/backport.yml) cherry-picks the commits and opens a
+PR against that branch. If the cherry-pick conflicts, do it manually:
+
+```
+git checkout release/v1.2.x
+git cherry-pick <commit>
+# resolve, then open a PR against release/v1.2.x
+```
+
 ## Reporting Issues
 
 Use [GitHub Issues](https://github.com/sara-star-quant/KioskOps-SDK-Android-Enterprise/issues) for:


### PR DESCRIPTION
## Summary

Establishes the long-term-support story: maintenance branches plus a label-triggered backport workflow. Last of the v1.3.0 feature PRs.

## Changes

- **Maintenance branches** (pushed separately): `release/v1.2.x` (from `v1.2.2`) and `release/v1.1.x` (from `v1.1.0`). These carry security backports; `main` stays the current line.
- **`.github/workflows/backport.yml`**: on a merged PR labelled `backport release/vX.Y.x`, `korthout/backport-action` (pinned by SHA) cherry-picks the commits and opens a PR against that branch. Uses only the action's own templating, no shell interpolation of untrusted input.
- **`CONTRIBUTING.md`**: documents the support matrix, the security-only policy for maintenance branches, the label convention, and the manual `git cherry-pick` fallback.

## Verification

- `backport.yml` parses as valid YAML; actions pinned by commit SHA.
- `release/v1.2.x` and `release/v1.1.x` exist on the remote at the expected commits.

## Note

The backport workflow only triggers on future labelled merges; nothing runs on this PR.
