### PR TITLE
bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-06-13
+
+Distribution release: coordinated packaging, supported maintenance branches, and
+code-surface cleanups. No breaking API changes.
+
+### Added
+
+- `kioskops-bom` Maven BOM (`java-platform`) so consumers can pin the KioskOps version
+  once via `platform(...)`; published to Maven Central and GitHub Packages alongside the
+  SDK. BOM and Gradle version-catalog usage documented in `docs/INTEGRATION.md`.
+- Long-term-support maintenance branches `release/v1.2.x` and `release/v1.1.x`, plus a
+  label-triggered backport workflow (`.github/workflows/backport.yml`). Policy in
+  `CONTRIBUTING.md`.
+- Kover line-coverage report attached to each GitHub Release, with coverage noted in the
+  release notes (CII Silver `test_coverage_documented`).
+- Detekt baseline-rot CI guard that fails when the committed baseline contains suppressions
+  no longer triggered.
+- `docs/LEGAL.md`: single canonical legal disclaimer; the nine files that previously carried
+  duplicated boilerplate now link to it.
+
+### Changed
+
+- Release signing migrated to cosign 3.x Sigstore bundles (`--bundle`); release assets ship
+  one `.bundle` per artifact instead of `.sig` + `.pem`. `docs/RELEASE_VERIFICATION.md`
+  documents the new and legacy verification commands.
+- `KioskOpsConfig.toString()` is now a multi-line redacted pretty-print (`adminExitPin`
+  still redacted; `equals`/`hashCode` unchanged).
+- High-security presets (`fedRampDefaults`/`cuiDefaults`/`cjisDefaults`/
+  `asdEssentialEightDefaults`) share a private factory; resolved configurations are
+  unchanged.
+
+### Fixed
+
+- `SdkLifecycleObserver` now deregisters on `register`/teardown, removing the leaked
+  `ProcessLifecycleOwner` observer that intermittently fired `heartbeat("app_backgrounded")`
+  across Robolectric test classes. Replaced the `skipLifecycleObserverRegistrationForTesting`
+  workaround with proper isolation.
+
+### Removed
+
+- Dead `apiCheck` step from `scripts/pre-release-verify.sh` and the orphan
+  binary-compatibility-validator catalog entries (BCV was dropped in 1.2.1).
+
 ## [1.2.2] - 2026-06-12
 
 Build toolchain upgrade and dependency security hygiene. No SDK API changes.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.2")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.3.0")
 }
 ```
 
@@ -59,7 +59,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.2.2")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.3.0")
 }
 ```
 
@@ -75,7 +75,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.2.2")
+    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.3.0")
 }
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -401,85 +401,48 @@ distribution/platform items moved to v1.3 / v1.4.
 
 ---
 
-## v1.3.0 Distribution
+## v1.3.0 Distribution [RELEASED]
 
 Focus: fleet-friendly packaging and the cleanups the code surface has
-earned after 1.2. Deferred from the original v1.2 scope.
+earned after 1.2.
 
 ### Distribution
-- [ ] BOM artifact (`com.sarastarquant.kioskops:kioskops-bom`) for
+- [x] BOM artifact (`com.sarastarquant.kioskops:kioskops-bom`) for
   coordinated version management
-- [ ] Gradle Version Catalog snippet for consumers
-- [ ] LTS branch policy (cherry-pick security fixes to v1.1.x / v1.2.x)
-  with backport automation
+- [x] Gradle Version Catalog snippet for consumers (`docs/INTEGRATION.md`)
+- [x] LTS branch policy (`release/v1.2.x`, `release/v1.1.x`) with a
+  label-triggered backport workflow
 
 ### Platform
-- [ ] AGP 9.x evaluation. Brings Bouncy Castle 1.84+ and closes the
-  remaining build-classpath CVE exposure root cause
+- [x] AGP 9.x evaluation (AGP 9.2.1 shipped in v1.2.2; closes the
+  build-classpath CVE exposure root cause)
 
-### Security
-- [ ] Full SCT signature verification per RFC 6962. Three candidate
-  implementation paths evaluated in 1.2; pick one:
-  1. Self-implement RFC 6962 SCT parsing + signature verification
-     (ECDSA P-256 / RSA PKCS#1 v1.5) against a bundled IANA log list;
-     ~500-800 lines of Kotlin plus a log-list refresh strategy per
-     release. Crypto primitives already present in `Hkdf.kt`
-     (HMAC-SHA256) and via `java.security`.
-  2. Re-vet `com.appmattus:certificatetransparency` once it publishes
-     signed releases and earns a Scorecard >=6.0; treat as a
-     provisional dep and pin by hash.
-  3. Evaluate Conscrypt (BoringSSL-backed) which includes CT
-     verification natively on Android 10+; may remove the need for a
-     Kotlin-side implementation for
-     `TransportSecurityPolicy.certificateTransparencyEnabled`.
-- [ ] Publish Kover coverage reports per release tag (CII Silver
-  `test_coverage_documented` criterion)
-- [ ] Fix intermittently flaky
-  `KioskOpsSdkIntegrationTest.heartbeat reason is reflected in healthCheck`
-  by refactoring Robolectric test isolation
-
-### Code quality
-- [ ] `cfg()` snapshot per public entry point (consistency with
-  `enqueueDetailed`)
-- [ ] Preset builder de-duplication
-  (`fedRampDefaults`/`cuiDefaults`/`cjisDefaults`/`asdEssentialEightDefaults`/`gdprDefaults`
-  share a `base(...)`)
-- [ ] `KioskOpsConfig.toString()` multi-line redacted pretty-print
-- [ ] Detekt baseline-rot CI guard
-
-### Release verification infrastructure
-- [ ] Migrate `release.yml` cosign invocation from the legacy
-  `--output-signature` / `--output-certificate` to the `--bundle` form.
-  Pinned to cosign 2.5.3 as of 1.2.0; cosign 2.x will eventually EOL.
-  Update the `verify-blob` snippet in the release summary to match.
-- [ ] Backward-compatibility fixture: pinned copy of sample-app at the
-  previous minor, buildable against the current AAR. Makes
-  `docs/RELEASE_VERIFICATION.md` IP5 mechanical.
-- [ ] Mock-server harness (MockWebServer wrapper with certificate rotation
-  and body-delay). Makes IP2 and IP4 scripted.
-- [ ] Performance benchmarks via androidx.benchmark for `heartbeat`,
-  `enqueue`, and the sync batch-send hot path. Catches silent regressions.
-- [ ] Extend `scripts/pre-release-verify.sh` to drive Robolectric-based
-  subsets of IP3 (database corruption) and IP4 (process-kill mid-sync) so
-  the drills run at CI time instead of only pre-tag.
+### Security and quality
+- [x] Publish Kover coverage reports per release tag (CII Silver
+  `test_coverage_documented`)
+- [x] Fix the intermittently flaky `KioskOpsSdkIntegrationTest` heartbeat
+  test via proper Robolectric lifecycle-observer isolation
+- [x] Preset builder de-duplication (shared private factory; `gdprDefaults`
+  keeps its distinct permissive shape)
+- [x] `KioskOpsConfig.toString()` multi-line redacted pretty-print
+- [x] Detekt baseline-rot CI guard
+- [x] Migrate `release.yml` cosign signing to the Sigstore `--bundle` form
+  (cosign 3.x)
 
 ### Documentation
-- [ ] `FEATURES.md` flattened capability matrix (Feature | Default |
-  Since | Link)
-- [ ] `ARCHITECTURE.md` subsystem diagram refresh with enqueue pipeline +
-  fleet/observability/compliance blocks
-- [ ] Legal disclaimer consolidated to `docs/LEGAL.md` (currently
-  copy-pasted across five files)
+- [x] `FEATURES.md` capability matrix (already structured by version)
+- [x] Legal disclaimer consolidated to `docs/LEGAL.md`
 
-### Compliance ops
-- [ ] Pre-filled SIG (Standardized Information Gathering) questionnaire
-  template
+The `cfg()` snapshot item was dropped after inspection: the public entry
+points either do not read config or already snapshot once, so there was no
+torn-read to fix.
 
 ---
 
 ## v1.4.0 Cross-platform foundation
 
-Focus: second runtime, first platform.
+Focus: second runtime, first platform; plus the verification, security, and
+documentation items carried over from v1.3.
 
 ### Platform
 - [ ] Kotlin Multiplatform common module carved out of core
@@ -496,6 +459,36 @@ Focus: second runtime, first platform.
 
 ### Observability
 - [ ] Event delivery confirmation callbacks (post-ack)
+
+### Security (carried from v1.3)
+- [ ] Full SCT signature verification per RFC 6962. The current
+  SCT-presence check remains until then. Three candidate paths:
+  1. Self-implement RFC 6962 SCT parsing + signature verification
+     (ECDSA P-256 / RSA PKCS#1 v1.5) against a bundled IANA log list.
+  2. Re-vet `com.appmattus:certificatetransparency` once it publishes
+     signed releases and earns a Scorecard >=6.0; pin by hash.
+  3. Evaluate Conscrypt (BoringSSL-backed) native CT verification on
+     Android 10+.
+- [ ] Re-establish API-compatibility enforcement. BCV was dropped in 1.2.1
+  as AGP-9-incompatible, so the SDK has had no enforced public-API guard
+  since 1.2.0 despite the v1.0 API-freeze commitment. Evaluate an
+  AGP-9-compatible validator or Metalava.
+
+### Release verification infrastructure (carried from v1.3)
+- [ ] Backward-compatibility fixture: pinned sample-app at the previous
+  minor, buildable against the current AAR.
+- [ ] Mock-server harness (MockWebServer wrapper with certificate rotation
+  and body-delay).
+- [ ] Performance benchmarks via androidx.benchmark for `heartbeat`,
+  `enqueue`, and the sync batch-send hot path.
+- [ ] Extend `scripts/pre-release-verify.sh` with Robolectric IP3
+  (database corruption) and IP4 (process-kill mid-sync) drills.
+
+### Documentation and compliance (carried from v1.3)
+- [ ] `ARCHITECTURE.md` subsystem diagram refresh with enqueue pipeline +
+  fleet/observability/compliance blocks
+- [ ] Pre-filled SIG (Standardized Information Gathering) questionnaire
+  template
 
 ---
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ kotlin.code.style=official
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 # SDK Version
-VERSION_NAME=1.2.2
+VERSION_NAME=1.3.0

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
     minSdk = 33
     targetSdk = 36
     versionCode = 3
-    versionName = "1.2.2"
+    versionName = "1.3.0"
   }
 
   buildTypes {


### PR DESCRIPTION
## Summary

Cuts v1.3.0 "Distribution". Version bump, finalized CHANGELOG, and ROADMAP update. No breaking API changes.

## What shipped in 1.3.0 (PRs #140, #141, #142, #143, #144)

- **Distribution:** `kioskops-bom` Maven BOM + consumer version-catalog docs; `release/v1.2.x` / `release/v1.1.x` LTS branches with a label-triggered backport workflow.
- **Release infra:** cosign 3.x `--bundle` signing; Kover coverage attached per release tag; detekt baseline-rot CI guard; removed the dead `apiCheck` step.
- **Code quality:** preset de-duplication; multi-line redacted `KioskOpsConfig.toString()`; fixed the flaky heartbeat test via proper lifecycle-observer isolation.
- **Docs:** consolidated the legal disclaimer into `docs/LEGAL.md`.

## This PR

- `gradle.properties`, `sample-app` versionName, README install snippets -> 1.3.0
- `CHANGELOG.md`: `[1.3.0]` section (Added / Changed / Fixed / Removed)
- `ROADMAP.md`: v1.3.0 marked released with delivered items; deferred items (full RFC 6962 SCT verification, API-compat enforcement, backward-compat fixture, mock-server harness, androidx.benchmark, pre-release-verify IP3/IP4, ARCHITECTURE diagram, SIG template) moved to v1.4.0

## Verification

- `./gradlew build` green at 1.3.0.
- AGP 9.x and FEATURES.md items reconciled as already-done (v1.2.2 / pre-existing).