### PR TITLE
fix release coverage zip path and scope backport permissions to job level

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,14 +8,16 @@ on:
     types: [closed, labeled]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   backport:
     name: Backport to maintenance branch
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           print(f'{int(c*100/(m+c))}%' if (m+c)>0 else 'N/A')")
           fi
           echo "COVERAGE=$COV" >> "$GITHUB_ENV"
-          (cd kiosk-ops-sdk/build/reports/kover && zip -qr "$GITHUB_WORKSPACE/kiosk-ops-sdk-coverage.zip" html)
+          (cd kiosk-ops-sdk/build/reports/kover && zip -qr "$GITHUB_WORKSPACE/kiosk-ops-sdk-coverage.zip" htmlDebug)
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2


### PR DESCRIPTION
- Kover HTML report dir is `htmlDebug/`, not `html/`; release coverage zip failed (exit 12) before publish. Fixed the path.
- backport.yml had workflow-level `contents: write` (Scorecard Token-Permissions -> 0). Moved write to job level, top-level `contents: read`.