### PR TITLE
bump dependencies in one batch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -195,7 +195,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/dokka-pages.yml
+++ b/.github/workflows/dokka-pages.yml
@@ -46,7 +46,7 @@ jobs:
           java-version: "21"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Generate Dokka HTML
         run: ./gradlew :kiosk-ops-sdk:dokkaGeneratePublicationHtml --no-daemon

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -21,4 +21,4 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Build release AAR
         run: ./gradlew :kiosk-ops-sdk:assembleRelease -PVERSION_NAME=${{ steps.version.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.sarastarquant.kioskops/kiosk-ops-sdk.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.sarastarquant.kioskops/kiosk-ops-sdk)
 [![JitPack](https://jitpack.io/v/sara-star-quant/KioskOps-SDK-Android-Enterprise.svg)](https://jitpack.io/#sara-star-quant/KioskOps-SDK-Android-Enterprise)
 [![API](https://img.shields.io/badge/API-33%2B-brightgreen.svg)](https://developer.android.com/about/versions/13)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.1-purple.svg)](https://kotlinlang.org/)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3-purple.svg)](https://kotlinlang.org/)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/Docs-Dokka-brightgreen.svg)](https://sara-star-quant.github.io/KioskOps-SDK-Android-Enterprise/)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.2.1"
-ksp = "2.3.6"
+ksp = "2.3.9"
 kotlin = "2.3.21"
 serializationJson = "1.11.0"
 jazzer = "0.22.1"


### PR DESCRIPTION
Aggregates the open Dependabot bumps into one PR (one CI run, rebase-merged).

- gradle/actions 6.1.0 -> 6.2.0 (CI)
- com.google.devtools.ksp 2.3.6 -> 2.3.9
- Kotlin badge -> 2.3

Held back (need follow-up, out of scope for a mechanical bump):
- kotlin 2.4.0 (builds, but CodeQL cannot analyze Kotlin 2.4.0 yet - github/codeql#21938; held at 2.3.21)
- okhttp 5.4.0 (expands Interceptor.Chain; needs a test-double refactor; held at 5.3.2)
- androidx.core:core-ktx 1.19.0 (requires compileSdk 37; held at 1.18.0)

Supersedes the individual Dependabot PRs #147-#151.