### PR TITLE
fix Maven Central publish for multi-module release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,13 +135,19 @@ jobs:
 
       - name: Create GitHub Release
         run: |
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes-file release_notes.md \
-            --latest \
-            kiosk-ops-sdk/build/outputs/aar/*.aar \
-            kiosk-ops-sdk/build/outputs/aar/*.bundle \
+          assets=(
+            kiosk-ops-sdk/build/outputs/aar/*.aar
+            kiosk-ops-sdk/build/outputs/aar/*.bundle
             kiosk-ops-sdk-coverage.zip
+          )
+          # Re-running a release (e.g. to retry a failed Maven Central publish) must not
+          # fail just because the release already exists. Create it, or refresh assets.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TAG" --notes-file release_notes.md --latest
+            gh release upload "$TAG" "${assets[@]}" --clobber
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file release_notes.md --latest "${assets[@]}"
+          fi
         env:
           TAG: ${{ steps.version.outputs.TAG }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,9 +100,7 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
-          ./gradlew :kiosk-ops-sdk:publishAndReleaseToMavenCentral :kioskops-bom:publishAndReleaseToMavenCentral --no-configuration-cache -PVERSION_NAME="$VERSION" || {
-            echo "::warning::Maven Central publish failed. Continuing."
-          }
+          ./gradlew :kiosk-ops-sdk:publishAndReleaseToMavenCentral :kioskops-bom:publishAndReleaseToMavenCentral --no-configuration-cache -PVERSION_NAME="$VERSION"
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
   alias(libs.plugins.android.library) apply false
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.ksp) apply false
+  // Load the publish plugin once at the root so kiosk-ops-sdk and kioskops-bom
+  // share a single MavenCentralBuildService classloader. Applying it only in the
+  // sibling subprojects loads the service twice and fails publishAndReleaseToMavenCentral.
+  alias(libs.plugins.maven.publish) apply false
 }
 
 subprojects {


### PR DESCRIPTION
## Summary

The v1.3.0 release reported green but never published to Maven Central. `kiosk-ops-sdk` on Central is still at 1.2.2 and `kioskops-bom` has never been published; both reached GitHub Packages only.

## Root cause

The vanniktech `com.vanniktech.maven.publish` plugin applied only inside the `kiosk-ops-sdk` and `kioskops-bom` subprojects. With the plugin absent from the root classpath, each module loaded its own copy of `MavenCentralBuildService` under a separate classloader scope. `publishAndReleaseToMavenCentral` then failed at configuration time:

```
Could not create task ':kioskops-bom:enableAutomaticMavenCentralPublishing'.
> Cannot set the value of task ... property 'buildService' of type
  com.vanniktech.maven.publish.central.MavenCentralBuildService loaded with
  ...project-kioskops-bom(export)... using a provider ...loaded with
  ...project-kiosk-ops-sdk(export).
```

The release step wrapped the Gradle call in `|| { echo "::warning::...Continuing." }`, so the failure surfaced as a warning annotation and the job still passed green.

## Changes

- Declare the publish plugin once at the root build with `apply false`, so both modules share a single build-service instance.
- Drop the warning-and-continue around the Maven Central step. A publish failure now fails the release instead of passing green.
- Make the Create GitHub Release step idempotent so a release can be safely re-run (needed to retry a failed publish without tripping over the existing release).

## Verification

`./gradlew :kiosk-ops-sdk:publishAndReleaseToMavenCentral :kioskops-bom:publishAndReleaseToMavenCentral --no-configuration-cache -PVERSION_NAME=1.3.0 --dry-run` reproduces the classloader failure before the change and resolves all publish tasks after it.
