### PR TITLE
fix JitPack builds by signing only when a key is present

### DIFF
--- a/kiosk-ops-sdk/build.gradle.kts
+++ b/kiosk-ops-sdk/build.gradle.kts
@@ -159,7 +159,12 @@ val javadocJar by tasks.registering(Jar::class) {
 // Maven Central publishing via Vanniktech plugin (handles Central Portal bundle upload)
 mavenPublishing {
   publishToMavenCentral()
-  signAllPublications()
+  // Sign only when a key is available. Maven Central requires signatures and the
+  // release workflow provides signingInMemoryKey. JitPack and local publishToMavenLocal
+  // builds have no key, so signAllPublications() there fails with "no configured signatory".
+  if (project.hasProperty("signingInMemoryKey")) {
+    signAllPublications()
+  }
 
   coordinates(
     groupId = "com.sarastarquant.kioskops",

--- a/kioskops-bom/build.gradle.kts
+++ b/kioskops-bom/build.gradle.kts
@@ -17,7 +17,12 @@ dependencies {
 // Maven Central publishing via Vanniktech plugin (POM-only platform artifact)
 mavenPublishing {
   publishToMavenCentral()
-  signAllPublications()
+  // Sign only when a key is available. Maven Central requires signatures and the
+  // release workflow provides signingInMemoryKey. JitPack and local publishToMavenLocal
+  // builds have no key, so signAllPublications() there fails with "no configured signatory".
+  if (project.hasProperty("signingInMemoryKey")) {
+    signAllPublications()
+  }
 
   coordinates(
     groupId = "com.sarastarquant.kioskops",


### PR DESCRIPTION
## Summary

The JitPack badge shows the latest tag name but JitPack has never produced a usable artifact for this repo. `latestOk` is empty and every version (back to v1.1.0) is in `Error`. This is independent of the Maven Central issue and predates it.

## Root cause

JitPack builds the SDK on its own servers via `./gradlew :kiosk-ops-sdk:publishToMavenLocal` (see `jitpack.yml`). The GPG signing key exists only as a GitHub Actions secret, so it is absent in JitPack's environment. Both modules call `signAllPublications()` unconditionally, so the build dies:

```
> Task :kiosk-ops-sdk:signMavenPublication FAILED
> Cannot perform signing task ':kiosk-ops-sdk:signMavenPublication'
  because it has no configured signatory
```

## Fix

Gate `signAllPublications()` on the presence of `signingInMemoryKey`. The release workflow provides it, so Maven Central still gets signed artifacts; JitPack and local `publishToMavenLocal` builds publish unsigned (JitPack does not require signatures).

## Verification

- `./gradlew :kiosk-ops-sdk:publishToMavenLocal :kioskops-bom:publishToMavenLocal -PVERSION_NAME=1.3.0 -x test` (no key) now succeeds; previously it failed at `signMavenPublication`.
- With `-PsigningInMemoryKey=...` present, `signMavenPublication` is still in the task graph for both modules, so the Maven Central path keeps signing.
