### PR TITLE
bump version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-06-20
+
+Release-pipeline fixes only. No API or runtime changes; artifacts are identical in behavior to 1.3.0.
+
+### Fixed
+
+- Maven Central multi-module publish. The vanniktech publish plugin loaded its `MavenCentralBuildService`
+  under two classloaders when applied only in the `kiosk-ops-sdk` and `kioskops-bom` subprojects, so
+  `publishAndReleaseToMavenCentral` failed and the release skipped Central. The plugin now loads once at the
+  root with `apply false`.
+- JitPack builds. `signAllPublications()` ran unconditionally, so JitPack (which has no signing key) failed
+  every build with "no configured signatory". Signing is now gated on `signingInMemoryKey`, so Maven Central
+  still ships signed artifacts while JitPack and local `publishToMavenLocal` builds succeed unsigned.
+- Release workflow no longer swallows a Maven Central publish failure as a warning, and the GitHub Release
+  step is idempotent so a release can be re-run safely.
+
 ## [1.3.0] - 2026-06-13
 
 Distribution release: coordinated packaging, supported maintenance branches, and

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.3.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.3.1")
 }
 ```
 
@@ -59,7 +59,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.3.0")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.3.1")
 }
 ```
 
@@ -75,7 +75,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.3.0")
+    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.3.1")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ kotlin.code.style=official
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 # SDK Version
-VERSION_NAME=1.3.0
+VERSION_NAME=1.3.1

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     applicationId = "com.sarastarquant.kioskops.sample"
     minSdk = 33
     targetSdk = 36
-    versionCode = 3
-    versionName = "1.3.0"
+    versionCode = 4
+    versionName = "1.3.1"
   }
 
   buildTypes {


### PR DESCRIPTION
## Summary

Patch release. 1.3.1 carries the release-pipeline fixes already merged to `main` (#155, #156) and gives JitPack a clean version to build. No API or runtime changes; the artifacts behave identically to 1.3.0.

## Why a new version

1.3.0 publishes correctly to Maven Central now (re-published after #155), but JitPack permanently pinned the `1.3.0` version to a pre-fix commit and will not rebuild a force-moved tag. Building the fixed commit directly on JitPack succeeds, so a fresh version number is the clean way to get a green JitPack build under a release tag.

## Changes

- `VERSION_NAME` 1.3.0 -> 1.3.1 (`gradle.properties`).
- Sample app `versionName` 1.3.0 -> 1.3.1, `versionCode` 3 -> 4.
- README install snippets (Maven Central x2, JitPack) bumped to 1.3.1.
- CHANGELOG 1.3.1 entry describing the pipeline fixes.

## Release steps after merge

1. Tag `v1.3.1` on the merge commit and push it.
2. Run the Release workflow with `tag=v1.3.1`.
3. Verify Maven Central `kiosk-ops-sdk:1.3.1` and `kioskops-bom:1.3.1`, and a green JitPack `1.3.1` build.
