### PR TITLE
add known-answer tests for AES-256-GCM and PBKDF2

### DIFF
--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/AesGcmBlob.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/AesGcmBlob.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.crypto
+
+import androidx.annotation.VisibleForTesting
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * AES-GCM transform and blob framing shared by the crypto providers.
+ *
+ * Blob format: [version:1][ivLen:1][iv][ciphertext||tag]. The transform is
+ * AES/GCM/NoPadding with a 128-bit authentication tag and no associated data.
+ * Centralizing it here keeps the keystore-backed and software providers on one
+ * byte format and gives the known-answer tests a single, deterministic seam.
+ */
+internal object AesGcmBlob {
+
+  const val VERSION: Int = 1
+  const val TAG_BITS: Int = 128
+  const val IV_LEN_BYTES: Int = 12
+
+  private const val TRANSFORM = "AES/GCM/NoPadding"
+
+  /** Encrypt [plain] under [key], generating a fresh random IV. */
+  fun seal(key: SecretKey, plain: ByteArray): ByteArray {
+    val cipher = Cipher.getInstance(TRANSFORM)
+    cipher.init(Cipher.ENCRYPT_MODE, key)
+    return frame(cipher.iv, cipher.doFinal(plain))
+  }
+
+  /** Decrypt a [blob] produced by [seal] / [sealWithIv]. */
+  fun open(key: SecretKey, blob: ByteArray): ByteArray {
+    require(blob.size >= 2 && blob[0].toInt() == VERSION) { "Unknown crypto blob version" }
+    val ivLen = blob[1].toInt()
+    require(ivLen in 12..32) { "Invalid IV length" }
+    val ctStart = 2 + ivLen
+    require(ctStart <= blob.size) { "Malformed crypto blob" }
+
+    val iv = blob.copyOfRange(2, ctStart)
+    val ct = blob.copyOfRange(ctStart, blob.size)
+    val cipher = Cipher.getInstance(TRANSFORM)
+    cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(TAG_BITS, iv))
+    return cipher.doFinal(ct)
+  }
+
+  /**
+   * Encrypt with a caller-supplied IV.
+   *
+   * Reusing an IV under the same key breaks GCM, so this is exposed only for
+   * known-answer tests that pin a published (key, IV, plaintext) vector. Never
+   * call it from production code.
+   */
+  @VisibleForTesting
+  fun sealWithIv(key: SecretKey, iv: ByteArray, plain: ByteArray): ByteArray {
+    val cipher = Cipher.getInstance(TRANSFORM)
+    cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(TAG_BITS, iv))
+    return frame(iv, cipher.doFinal(plain))
+  }
+
+  private fun frame(iv: ByteArray, ct: ByteArray): ByteArray {
+    val out = ByteArray(2 + iv.size + ct.size)
+    out[0] = VERSION.toByte()
+    out[1] = iv.size.toByte()
+    System.arraycopy(iv, 0, out, 2, iv.size)
+    System.arraycopy(ct, 0, out, 2 + iv.size, ct.size)
+    return out
+  }
+}

--- a/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/AesGcmKeystoreCryptoProvider.kt
+++ b/kiosk-ops-sdk/src/main/java/com/sarastarquant/kioskops/sdk/crypto/AesGcmKeystoreCryptoProvider.kt
@@ -3,11 +3,8 @@ package com.sarastarquant.kioskops.sdk.crypto
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import java.security.KeyStore
-import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
-import javax.crypto.spec.GCMParameterSpec
-import javax.crypto.spec.SecretKeySpec
 
 /**
  * AES-GCM with a hardware-backed key when available.
@@ -39,34 +36,7 @@ class AesGcmKeystoreCryptoProvider(
     return gen.generateKey()
   }
 
-  override fun encrypt(plain: ByteArray): ByteArray {
-    val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-    cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
-    val iv = cipher.iv
-    val ct = cipher.doFinal(plain)
+  override fun encrypt(plain: ByteArray): ByteArray = AesGcmBlob.seal(getOrCreateKey(), plain)
 
-    val out = ByteArray(2 + iv.size + ct.size)
-    out[0] = 1
-    out[1] = iv.size.toByte()
-    System.arraycopy(iv, 0, out, 2, iv.size)
-    System.arraycopy(ct, 0, out, 2 + iv.size, ct.size)
-    return out
-  }
-
-  override fun decrypt(blob: ByteArray): ByteArray {
-    require(blob.isNotEmpty() && blob[0].toInt() == 1) { "Unknown crypto blob version" }
-    val ivLen = blob[1].toInt()
-    require(ivLen in 12..32) { "Invalid IV length" }
-
-    val ivStart = 2
-    val ctStart = ivStart + ivLen
-    require(ctStart <= blob.size) { "Malformed crypto blob" }
-
-    val iv = blob.copyOfRange(ivStart, ctStart)
-    val ct = blob.copyOfRange(ctStart, blob.size)
-
-    val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-    cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), GCMParameterSpec(128, iv))
-    return cipher.doFinal(ct)
-  }
+  override fun decrypt(blob: ByteArray): ByteArray = AesGcmBlob.open(getOrCreateKey(), blob)
 }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/AesGcmKatTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/AesGcmKatTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.crypto
+
+import com.google.common.truth.Truth.assertThat
+import javax.crypto.AEADBadTagException
+import javax.crypto.spec.SecretKeySpec
+import org.junit.Test
+
+/**
+ * Known-answer tests for the SDK's AES-256-GCM transform against the published
+ * vectors in McGrew & Viega, "The Galois/Counter Mode of Operation (GCM)"
+ * (the NIST SP 800-38D reference vectors), AES-256 test cases 13-15.
+ *
+ * These run through [AesGcmBlob] - the exact code path used by the shipped
+ * [AesGcmKeystoreCryptoProvider] - so a pass proves the SDK's parameters
+ * (256-bit key, 96-bit IV, 128-bit tag, no AAD) and blob framing are correct,
+ * not merely that the JDK ships a working AES. The Keystore-backed key path
+ * itself requires hardware and is exercised by instrumented tests.
+ */
+class AesGcmKatTest {
+
+  // GCM spec Test Case 13: 256-bit zero key, zero IV, empty plaintext.
+  @Test
+  fun `case 13 empty plaintext matches published tag`() {
+    val key = aesKey("0000000000000000000000000000000000000000000000000000000000000000")
+    val iv = hex("000000000000000000000000")
+    val expectedCtAndTag = hex("530f8afbc74536b9a963b4f1c4cb738b")
+
+    val blob = AesGcmBlob.sealWithIv(key, iv, ByteArray(0))
+
+    assertThat(ciphertextAndTag(blob, iv.size)).isEqualTo(expectedCtAndTag)
+    assertThat(AesGcmBlob.open(key, blob)).isEqualTo(ByteArray(0))
+  }
+
+  // GCM spec Test Case 14: 256-bit zero key, zero IV, one zero block of plaintext.
+  @Test
+  fun `case 14 single block matches published ciphertext and tag`() {
+    val key = aesKey("0000000000000000000000000000000000000000000000000000000000000000")
+    val iv = hex("000000000000000000000000")
+    val plain = hex("00000000000000000000000000000000")
+    val expectedCtAndTag = hex(
+      "cea7403d4d606b6e074ec5d3baf39d18" + "d0d1c8a799996bf0265b98b5d48ab919",
+    )
+
+    val blob = AesGcmBlob.sealWithIv(key, iv, plain)
+
+    assertThat(ciphertextAndTag(blob, iv.size)).isEqualTo(expectedCtAndTag)
+    assertThat(AesGcmBlob.open(key, blob)).isEqualTo(plain)
+  }
+
+  // GCM spec Test Case 15: full 64-byte plaintext, no associated data.
+  @Test
+  fun `case 15 multi block matches published ciphertext and tag`() {
+    val key = aesKey("feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308")
+    val iv = hex("cafebabefacedbaddecaf888")
+    val plain = hex(
+      "d9313225f88406e5a55909c5aff5269a" +
+        "86a7a9531534f7da2e4c303d8a318a72" +
+        "1c3c0c95956809532fcf0e2449a6b525" +
+        "b16aedf5aa0de657ba637b391aafd255",
+    )
+    val expectedCtAndTag = hex(
+      "522dc1f099567d07f47f37a32a84427d" +
+        "643a8cdcbfe5c0c97598a2bd2555d1aa" +
+        "8cb08e48590dbb3da7b08b1056828838" +
+        "c5f61e6393ba7a0abcc9f662898015ad" +
+        "b094dac5d93471bdec1a502270e3cc6c",
+    )
+
+    val blob = AesGcmBlob.sealWithIv(key, iv, plain)
+
+    assertThat(ciphertextAndTag(blob, iv.size)).isEqualTo(expectedCtAndTag)
+    assertThat(AesGcmBlob.open(key, blob)).isEqualTo(plain)
+  }
+
+  @Test(expected = AEADBadTagException::class)
+  fun `tampered tag is rejected`() {
+    val key = aesKey("0000000000000000000000000000000000000000000000000000000000000000")
+    val blob = AesGcmBlob.sealWithIv(key, hex("000000000000000000000000"), hex("00000000000000000000000000000000"))
+
+    blob[blob.size - 1] = (blob[blob.size - 1].toInt() xor 0x01).toByte()
+
+    AesGcmBlob.open(key, blob)
+  }
+
+  private fun ciphertextAndTag(blob: ByteArray, ivLen: Int): ByteArray =
+    blob.copyOfRange(2 + ivLen, blob.size)
+
+  private fun aesKey(hex: String) = SecretKeySpec(hex(hex), "AES")
+
+  private fun hex(s: String): ByteArray {
+    val clean = s.replace(" ", "")
+    return ByteArray(clean.length / 2) { i ->
+      clean.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+    }
+  }
+}

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/Pbkdf2KatTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/Pbkdf2KatTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.crypto
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Known-answer tests for PBKDF2 against published vectors, run through the
+ * SDK's own [SecureKeyDerivation.deriveKeyWithSalt]. A pass proves the SDK
+ * derives the exact bytes the standards specify, not just that derivation is
+ * internally consistent.
+ *
+ * SHA-1 vector: RFC 6070 section 2 (case 5, the embedded-NUL case, truncated to
+ * a 128-bit key so it maps onto the SDK's supported key lengths).
+ * SHA-256 vectors: the widely cited PBKDF2-HMAC-SHA256 vectors for
+ * password="password", salt="salt".
+ */
+class Pbkdf2KatTest {
+
+  @Test
+  fun `PBKDF2-HMAC-SHA1 matches RFC 6070 case 5`() {
+    val derivation = SecureKeyDerivation(
+      KeyDerivationConfig(
+        algorithm = "PBKDF2WithHmacSHA1",
+        iterationCount = 4096,
+        saltLengthBytes = 16,
+        keyLengthBits = 128,
+      ),
+    )
+
+    val key = derivation.deriveKeyWithSalt("pass\u0000word".toCharArray(), "sa\u0000lt".toByteArray())
+
+    assertThat(key.encoded).isEqualTo(hex("56fa6aa75548099dcc37d7f03425e0c3"))
+  }
+
+  @Test
+  fun `PBKDF2-HMAC-SHA256 matches vector at 1 iteration`() {
+    val key = deriveSha256(iterations = 1)
+    assertThat(key.encoded).isEqualTo(
+      hex("120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b"),
+    )
+  }
+
+  @Test
+  fun `PBKDF2-HMAC-SHA256 matches vector at 4096 iterations`() {
+    val key = deriveSha256(iterations = 4096)
+    assertThat(key.encoded).isEqualTo(
+      hex("c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a"),
+    )
+  }
+
+  private fun deriveSha256(iterations: Int) = SecureKeyDerivation(
+    KeyDerivationConfig(
+      algorithm = "PBKDF2WithHmacSHA256",
+      iterationCount = iterations,
+      saltLengthBytes = 16,
+      keyLengthBits = 256,
+    ),
+  ).deriveKeyWithSalt("password".toCharArray(), "salt".toByteArray())
+
+  private fun hex(s: String): ByteArray =
+    ByteArray(s.length / 2) { i -> s.substring(i * 2, i * 2 + 2).toInt(16).toByte() }
+}

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/SoftwareAesGcmCryptoProvider.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/SoftwareAesGcmCryptoProvider.kt
@@ -1,36 +1,14 @@
 package com.sarastarquant.kioskops.sdk.crypto
 
-import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
-import javax.crypto.spec.GCMParameterSpec
 
 /** Test-only crypto provider (JVM) */
 class SoftwareAesGcmCryptoProvider : CryptoProvider {
   override val isEnabled: Boolean = true
   private val key: SecretKey = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
 
-  override fun encrypt(plain: ByteArray): ByteArray {
-    val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-    cipher.init(Cipher.ENCRYPT_MODE, key)
-    val iv = cipher.iv
-    val ct = cipher.doFinal(plain)
+  override fun encrypt(plain: ByteArray): ByteArray = AesGcmBlob.seal(key, plain)
 
-    val out = ByteArray(2 + iv.size + ct.size)
-    out[0] = 1
-    out[1] = iv.size.toByte()
-    System.arraycopy(iv, 0, out, 2, iv.size)
-    System.arraycopy(ct, 0, out, 2 + iv.size, ct.size)
-    return out
-  }
-
-  override fun decrypt(blob: ByteArray): ByteArray {
-    require(blob.isNotEmpty() && blob[0].toInt() == 1)
-    val ivLen = blob[1].toInt()
-    val iv = blob.copyOfRange(2, 2 + ivLen)
-    val ct = blob.copyOfRange(2 + ivLen, blob.size)
-    val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-    cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, iv))
-    return cipher.doFinal(ct)
-  }
+  override fun decrypt(blob: ByteArray): ByteArray = AesGcmBlob.open(key, blob)
 }


### PR DESCRIPTION
## Summary

Crypto had round-trip tests only, plus a single HKDF RFC 5869 vector. This change adds published known-answer tests so the AES-256-GCM and PBKDF2 primitives are proven correct against the standards, not just internally consistent.

## Changes

- Extract the AES-GCM transform and blob framing (`[v][ivLen][iv][ct||tag]`, AES/GCM/NoPadding, 128-bit tag) into an internal `AesGcmBlob`; `AesGcmKeystoreCryptoProvider` and the software test provider both delegate to it. This gives the GCM KAT a single deterministic seam that exercises the shipped code path; the public API stays the same.
- `AesGcmKatTest`: NIST SP 800-38D / GCM spec AES-256 cases 13, 14, 15, plus tag-tamper rejection.
- `Pbkdf2KatTest`: RFC 6070 (PBKDF2-HMAC-SHA1) and the standard PBKDF2-HMAC-SHA256 vectors, run through `SecureKeyDerivation`.

## Notes

The Keystore-backed key path needs hardware and stays covered by instrumented tests; the KAT pins the transform, parameters, and framing. Vectors are inlined as hex with citations, matching the existing HKDF test style. No new runtime dependency.

## Verification

`./gradlew :kiosk-ops-sdk:testDebugUnitTest --tests '*Kat*'` passes (7 tests). Corrupting one expected vector byte fails the test, confirming the values come from the published vectors rather than the implementation. Full crypto suite and detekt pass.
