### PR TITLE
add microbenchmarks for anomaly scoring and field encryption

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,74 @@
+name: Benchmark
+
+# Microbenchmarks run on an emulator and are directional only, so this never
+# gates PRs. Trigger manually or on the weekly schedule; treat physical-device
+# runs as authoritative.
+on:
+  schedule:
+    - cron: '0 4 * * 0'  # Weekly on Sunday at 4 AM
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install Android emulator
+        run: |
+          yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
+            "emulator" \
+            "system-images;android-33;default;x86_64" \
+            "platform-tools" \
+            "platforms;android-33"
+
+      - name: Create and start emulator
+        run: |
+          export ANDROID_EMULATOR_HOME="$HOME/.android"
+          export ANDROID_AVD_HOME="$HOME/.android/avd"
+          mkdir -p "$ANDROID_AVD_HOME"
+
+          echo "no" | "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" create avd \
+            --name "bench_avd" \
+            --package "system-images;android-33;default;x86_64" \
+            --device "pixel_6" \
+            --force
+
+          "$ANDROID_HOME/emulator/emulator" -avd bench_avd \
+            -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect &
+
+          echo "Waiting for emulator boot..."
+          "$ANDROID_HOME/platform-tools/adb" wait-for-device shell \
+            'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;'
+          "$ANDROID_HOME/platform-tools/adb" shell input keyevent 82
+
+      - name: Run microbenchmarks
+        run: ./gradlew :benchmark:connectedReleaseAndroidTest --no-daemon
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.0
+        with:
+          name: benchmark-results
+          path: '**/connected_android_test_additional_output/**/*-benchmarkData.json'
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ val accepted = KioskOpsSdk.get().enqueueBlocking("button_press", """{"screen": "
 
 See [Features](docs/FEATURES.md) for the complete list.
 
+## Performance
+
+Microbenchmarks of the per-event hot paths (emulator `sdk_gphone64_arm64`, API 34;
+directional, not production hardware):
+
+| Operation | Median | Throughput |
+|-----------|--------|------------|
+| Anomaly scoring (per event) | 4.8 us | ~207k events/s |
+| Field encryption, 3 fields (AES-256-GCM) | 46.1 us | ~22k ops/s |
+| Field decryption, 3 fields | 39.2 us | ~25k ops/s |
+
+See [Benchmarks](docs/benchmarks.md) for methodology and how to reproduce.
+
 ## Requirements
 
 | Requirement | Version |
@@ -143,6 +156,7 @@ See [Features](docs/FEATURES.md) for the complete list.
 | [Integration Guide](docs/INTEGRATION.md) | Step-by-step setup |
 | [Architecture](docs/ARCHITECTURE.md) | System design, modules, and scope |
 | [Features](docs/FEATURES.md) | Full feature list and limitations |
+| [Benchmarks](docs/benchmarks.md) | Microbenchmark results and reproduction |
 | [Security and Compliance](docs/SECURITY_COMPLIANCE.md) | Threat model, transport security, key management, audit integrity |
 | [Compliance Mappings](docs/compliance/) | NIST 800-171, CJIS, ASD, BSI, Australian Privacy Act |
 | [Server API Contract](docs/openapi.yaml) | OpenAPI spec for batch ingest |

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.androidx.benchmark)
+}
+
+kotlin {
+  jvmToolchain(21)
+}
+
+android {
+  namespace = "com.sarastarquant.kioskops.benchmark"
+  compileSdk = 36
+
+  defaultConfig {
+    minSdk = 33
+    testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
+    // Emulator results are directional only, not representative of real devices.
+    // Suppress the hard stop so CI and local emulator runs still produce numbers;
+    // treat physical-device runs as authoritative.
+    testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR"
+  }
+
+  // Microbenchmarks must run against release-quality code (R8, no debuggable flag).
+  testBuildType = "release"
+
+  buildTypes {
+    release {
+      isMinifyEnabled = false
+    }
+  }
+}
+
+dependencies {
+  androidTestImplementation(project(":kiosk-ops-sdk"))
+  androidTestImplementation(libs.androidx.benchmark.junit4)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(libs.androidx.test.ext.junit)
+  androidTestImplementation(libs.junit4)
+}

--- a/benchmark/src/androidTest/java/com/sarastarquant/kioskops/benchmark/AnomalyDetectorBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/sarastarquant/kioskops/benchmark/AnomalyDetectorBenchmark.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.sarastarquant.kioskops.sdk.anomaly.AnomalyPolicy
+import com.sarastarquant.kioskops.sdk.anomaly.StatisticalAnomalyDetector
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Per-event scoring throughput of [StatisticalAnomalyDetector] once past its
+ * learning period (the path taken for every enqueued event in production).
+ */
+@RunWith(AndroidJUnit4::class)
+class AnomalyDetectorBenchmark {
+
+  @get:Rule
+  val benchmarkRule = BenchmarkRule()
+
+  private val detector = StatisticalAnomalyDetector(AnomalyPolicy.enabledDefaults())
+  private val eventType = "kiosk_heartbeat"
+  private val payload =
+    """{"battery":87,"uptimeMs":1234567,"appVersion":"1.3.1","screen":"locked","temp":31.5}"""
+
+  init {
+    // Warm past baselineEventCount so analyze() actually scores instead of returning ALLOW.
+    repeat(200) { detector.analyze(eventType, payload) }
+  }
+
+  @Test
+  fun analyze() {
+    benchmarkRule.measureRepeated {
+      detector.analyze(eventType, payload)
+    }
+  }
+}

--- a/benchmark/src/androidTest/java/com/sarastarquant/kioskops/benchmark/FieldEncryptionBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/sarastarquant/kioskops/benchmark/FieldEncryptionBenchmark.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.sarastarquant.kioskops.sdk.crypto.FieldLevelEncryptor
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Throughput of field-level AES-256-GCM encryption through the shipped
+ * [FieldLevelEncryptor]. Uses an in-memory software key so the measurement
+ * reflects the cipher, not AndroidKeyStore round-trips (see [SoftwareAesGcmProvider]).
+ */
+@RunWith(AndroidJUnit4::class)
+class FieldEncryptionBenchmark {
+
+  @get:Rule
+  val benchmarkRule = BenchmarkRule()
+
+  private val encryptor = FieldLevelEncryptor(SoftwareAesGcmProvider())
+  private val fields = setOf("email", "phone", "ssn")
+  private val payload =
+    """{"email":"user@example.com","phone":"+15551234567","ssn":"123-45-6789","note":"clear"}"""
+  private val encrypted = encryptor.encryptFields(payload, fields)
+
+  @Test
+  fun encryptFields() {
+    benchmarkRule.measureRepeated {
+      encryptor.encryptFields(payload, fields)
+    }
+  }
+
+  @Test
+  fun decryptFields() {
+    benchmarkRule.measureRepeated {
+      encryptor.decryptFields(encrypted)
+    }
+  }
+}

--- a/benchmark/src/androidTest/java/com/sarastarquant/kioskops/benchmark/SoftwareAesGcmProvider.kt
+++ b/benchmark/src/androidTest/java/com/sarastarquant/kioskops/benchmark/SoftwareAesGcmProvider.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.benchmark
+
+import com.sarastarquant.kioskops.sdk.crypto.CryptoProvider
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Software AES-256-GCM provider for benchmarking the encryption algorithm in
+ * isolation. The shipped [com.sarastarquant.kioskops.sdk.crypto.AesGcmKeystoreCryptoProvider]
+ * reloads the AndroidKeyStore on every call, so benchmarking it measures keystore
+ * round-trips, not the cipher. This holds the key in memory to surface the
+ * cipher cost itself; it mirrors the blob format the shipped provider uses.
+ */
+class SoftwareAesGcmProvider : CryptoProvider {
+  override val isEnabled: Boolean = true
+  private val key: SecretKey = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+
+  override fun encrypt(plain: ByteArray): ByteArray {
+    val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+    cipher.init(Cipher.ENCRYPT_MODE, key)
+    val iv = cipher.iv
+    val ct = cipher.doFinal(plain)
+    val out = ByteArray(2 + iv.size + ct.size)
+    out[0] = 1
+    out[1] = iv.size.toByte()
+    System.arraycopy(iv, 0, out, 2, iv.size)
+    System.arraycopy(ct, 0, out, 2 + iv.size, ct.size)
+    return out
+  }
+
+  override fun decrypt(blob: ByteArray): ByteArray {
+    val ivLen = blob[1].toInt()
+    val iv = blob.copyOfRange(2, 2 + ivLen)
+    val ct = blob.copyOfRange(2 + ivLen, blob.size)
+    val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+    cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, iv))
+    return cipher.doFinal(ct)
+  }
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,45 @@
+# Benchmarks
+
+Microbenchmarks for the SDK's compute-bound hot paths, measured with
+[androidx.benchmark](https://developer.android.com/studio/profile/benchmarking).
+They run through the shipped SDK classes in the `:benchmark` module.
+
+## Results
+
+Measured on an emulator (`sdk_gphone64_arm64`, API 34, arm64). Emulator numbers
+are directional, not representative of production hardware; treat physical-device
+runs as authoritative. Reproduce with the command below and substitute your own
+device's numbers.
+
+| Operation | Median | Throughput | Allocations |
+|-----------|--------|------------|-------------|
+| `StatisticalAnomalyDetector.analyze` (per event) | 4.8 us | ~207,000 events/s | 47 |
+| `FieldLevelEncryptor.encryptFields` (3 fields) | 46.1 us | ~21,700 ops/s | 492 |
+| `FieldLevelEncryptor.decryptFields` (3 fields) | 39.2 us | ~25,500 ops/s | 444 |
+
+Field encryption uses a software AES-256-GCM key so the number reflects the
+cipher and JSON envelope work. The shipped `AesGcmKeystoreCryptoProvider` adds an
+AndroidKeyStore lookup per call; that cost is device-specific (TEE/StrongBox) and
+is not captured here.
+
+## Reproduce
+
+```bash
+# Requires a connected device or emulator.
+./gradlew :benchmark:connectedReleaseAndroidTest
+```
+
+Results are written to
+`benchmark/build/outputs/connected_android_test_additional_output/releaseAndroidTest/connected/<device>/*-benchmarkData.json`.
+
+CI runs these weekly and on demand via the `Benchmark` workflow and uploads the
+JSON as an artifact. The workflow does not gate pull requests.
+
+## Scope
+
+The benchmarks cover the per-event compute paths that run on the enqueue hot
+path: anomaly scoring and field-level encryption. The audit hash chain is not
+microbenchmarked: `PersistentAuditTrail` is Room-backed, so its cost is dominated
+by disk IO rather than CPU, which makes it a poor microbenchmark target (each
+iteration would fsync). Audit append/verify is exercised for correctness by the
+instrumented and unit tests instead.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ androidxTestCore = "1.7.0"
 androidxTestRunner = "1.7.0"
 androidxTestRules = "1.7.0"
 androidxTestExtJunit = "1.3.0"
+androidxBenchmark = "1.5.0-alpha06"
 dokka = "2.2.0"
 detekt = "1.23.8"
 kover = "0.9.8"
@@ -60,12 +61,14 @@ androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTes
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxTestRules" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }
+androidx-benchmark-junit4 = { module = "androidx.benchmark:benchmark-junit4", version.ref = "androidxBenchmark" }
 
 [plugins]
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+androidx-benchmark = { id = "androidx.benchmark", version.ref = "androidxBenchmark" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,4 +19,4 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "KioskOpsSdk"
-include(":kiosk-ops-sdk", ":sample-app", ":kioskops-bom")
+include(":kiosk-ops-sdk", ":sample-app", ":kioskops-bom", ":benchmark")


### PR DESCRIPTION
## Summary

The SDK shipped no performance data. This change adds an `androidx.benchmark` module that measures the per-event compute hot paths through the shipped classes, and publishes the numbers in `docs/benchmarks.md` and the README.

## Changes

- New `:benchmark` microbenchmark module (`androidx.benchmark` 1.5.0-alpha06, the version compatible with AGP 9). Covers anomaly scoring (`StatisticalAnomalyDetector.analyze`) and field-level AES-256-GCM encrypt/decrypt (`FieldLevelEncryptor`).
- Field encryption runs against an in-memory software key so the number reflects the cipher and JSON envelope work, not AndroidKeyStore round-trips.
- `Benchmark` workflow runs the suite on an emulator weekly and on demand, and uploads the JSON. It does not gate pull requests.
- `docs/benchmarks.md` and a README Performance section record the numbers, labeled as directional emulator results.

## Notes

The Room-backed audit trail is intentionally not microbenchmarked: disk IO dominates its cost (a measureRepeated of `record` fsyncs every iteration), which makes it a poor microbenchmark target. Audit append and verify stay covered for correctness by the existing tests.

## Verification

`./gradlew :benchmark:connectedReleaseAndroidTest` passes on a standard phone emulator (`sdk_gphone64_arm64`, API 34). Medians: anomaly scoring 4.8 us/event; field encrypt 46 us, decrypt 39 us for three fields.
