### PR TITLE
link compliance controls to conformance tests

### DIFF
--- a/docs/compliance/NIST-SP-800-171-mapping.md
+++ b/docs/compliance/NIST-SP-800-171-mapping.md
@@ -4,6 +4,10 @@
 > advice; see [LEGAL.md](../LEGAL.md). Many 800-171 controls require organizational policy,
 > infrastructure, and host-application measures beyond SDK scope.
 
+> **Conformance evidence:** Controls the SDK enforces technically are backed by
+> executable tests. See [traceability.md](traceability.md) for the control-to-test
+> matrix, generated from `@ComplianceControl` annotations and verified in CI.
+
 ## Scope
 
 NIST SP 800-171 protects Controlled Unclassified Information (CUI) in

--- a/docs/compliance/traceability.md
+++ b/docs/compliance/traceability.md
@@ -1,0 +1,9 @@
+# Compliance control traceability
+
+Generated from `@ComplianceControl` annotations by `ComplianceTraceabilityTest`.
+Do not edit by hand; run `./gradlew :kiosk-ops-sdk:testDebugUnitTest -Pcompliance.update` to regenerate.
+
+| Framework | Control | Verified by |
+|-----------|---------|-------------|
+| NIST SP 800-171 | 3.13.11 | AesGcmKatTest; FipsComplianceCheckerTest.check returns result with provider info; KioskOpsConfigTest.cuiDefaults enforces NIST SP 800-171 controls; Pbkdf2KatTest |
+| NIST SP 800-171 | 3.3.1 | KioskOpsConfigTest.cuiDefaults enforces NIST SP 800-171 controls; RetentionEnforcerTest.maximalist defaults include 365 day minimum audit retention |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidxTestRunner = "1.7.0"
 androidxTestRules = "1.7.0"
 androidxTestExtJunit = "1.3.0"
 androidxBenchmark = "1.5.0-alpha06"
+classgraph = "4.8.179"
 dokka = "2.2.0"
 detekt = "1.23.8"
 kover = "0.9.8"
@@ -57,6 +58,7 @@ junit5-vintage = { module = "org.junit.vintage:junit-vintage-engine", version.re
 jazzer-junit = { module = "com.code-intelligence:jazzer-junit", version.ref = "jazzer" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxTestRules" }

--- a/kiosk-ops-sdk/build.gradle.kts
+++ b/kiosk-ops-sdk/build.gradle.kts
@@ -49,6 +49,10 @@ android {
         // Jazzer's JUnit extension conflicts with Robolectric's sandbox classloader.
         // Run fuzz tests separately: ./gradlew :kiosk-ops-sdk:fuzzTest
         test.filter.excludeTestsMatching("com.sarastarquant.kioskops.sdk.fuzz.*")
+        // Locate compliance docs for the traceability check; pass -Pcompliance.update
+        // to regenerate docs/compliance/traceability.md instead of verifying it.
+        test.systemProperty("compliance.docsDir", "${rootProject.projectDir}/docs/compliance")
+        test.systemProperty("compliance.update", project.hasProperty("compliance.update").toString())
       }
     }
   }
@@ -125,6 +129,7 @@ dependencies {
 
   testImplementation(libs.junit4)
   testImplementation(libs.truth)
+  testImplementation(libs.classgraph)
   testImplementation(libs.robolectric)
   testImplementation(libs.androidx.test.core)
   testImplementation(libs.okhttp.mockwebserver)

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsConfigTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/KioskOpsConfigTest.kt
@@ -6,6 +6,7 @@
 package com.sarastarquant.kioskops.sdk
 
 import com.google.common.truth.Truth.assertThat
+import com.sarastarquant.kioskops.sdk.compliance.ComplianceControl
 import com.sarastarquant.kioskops.sdk.compliance.SecurityPolicy
 import com.sarastarquant.kioskops.sdk.pii.DataClassification
 import com.sarastarquant.kioskops.sdk.pii.PiiAction
@@ -107,6 +108,8 @@ class KioskOpsConfigTest {
   }
 
   @Test
+  @ComplianceControl(framework = "NIST SP 800-171", control = "3.3.1")
+  @ComplianceControl(framework = "NIST SP 800-171", control = "3.13.11")
   fun `cuiDefaults enforces NIST SP 800-171 controls`() {
     val config = KioskOpsConfig.cuiDefaults("https://api.example.com/", "CUI-001")
 

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/ComplianceControl.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/ComplianceControl.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.compliance
+
+/**
+ * Marks a test as conformance evidence for a specific compliance control.
+ *
+ * The control-to-test traceability matrix in `docs/compliance/traceability.md`
+ * is generated from these annotations, and [ComplianceTraceabilityTest] fails
+ * the build if the matrix is stale or if an annotation cites a control that the
+ * framework's mapping document does not list.
+ *
+ * @property framework Framework name, matching a mapping document under
+ *   `docs/compliance` (e.g. "NIST SP 800-171").
+ * @property control Control identifier as written in that document (e.g. "3.13.11").
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Repeatable
+annotation class ComplianceControl(
+  val framework: String,
+  val control: String,
+)

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/ComplianceTraceabilityTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/ComplianceTraceabilityTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 SARA STAR QUANT LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+package com.sarastarquant.kioskops.sdk.compliance
+
+import com.google.common.truth.Truth.assertThat
+import io.github.classgraph.ClassGraph
+import java.io.File
+import org.junit.Test
+
+/**
+ * Generates and verifies the control-to-test traceability matrix from
+ * [ComplianceControl] annotations.
+ *
+ * Run `./gradlew :kiosk-ops-sdk:testDebugUnitTest -Pcompliance.update` to
+ * (re)write `docs/compliance/traceability.md`. In normal/CI runs this test only
+ * reads, and fails if:
+ *  - the committed matrix is out of date (an annotation was added/changed), or
+ *  - an annotation cites a control that its framework mapping document does not
+ *    list, or a framework has no mapping document.
+ *
+ * This mirrors the repo's generate-then-verify pattern (the .api binary-compat
+ * file and the detekt baseline work the same way): the artifact is committed,
+ * and the build fails on drift.
+ */
+class ComplianceTraceabilityTest {
+
+  private data class Entry(val framework: String, val control: String, val test: String)
+
+  private val frameworkDoc = mapOf(
+    "NIST SP 800-171" to "NIST-SP-800-171-mapping.md",
+  )
+
+  private val docsDir = File(
+    System.getProperty("compliance.docsDir")
+      ?: error("compliance.docsDir system property not set (configured in build.gradle.kts)"),
+  )
+  private val matrixFile = File(docsDir, "traceability.md")
+
+  @Test
+  fun `traceability matrix is current and every cited control exists`() {
+    val entries = scanAnnotations()
+    assertThat(entries).isNotEmpty()
+
+    val expected = render(entries)
+
+    if (System.getProperty("compliance.update") == "true") {
+      matrixFile.writeText(expected)
+      return
+    }
+
+    // Every cited control must appear in its framework's mapping document.
+    for ((framework, control) in entries.map { it.framework to it.control }.toSortedSet(compareBy({ it.first }, { it.second }))) {
+      val docName = frameworkDoc[framework]
+        ?: error("No mapping document registered for framework \"$framework\" in ComplianceTraceabilityTest.frameworkDoc")
+      val doc = File(docsDir, docName)
+      assertThat(doc.exists()).isTrue()
+      assertThat(doc.readText()).contains(control)
+    }
+
+    val actual = if (matrixFile.exists()) matrixFile.readText() else ""
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  private fun scanAnnotations(): List<Entry> {
+    val annName = ComplianceControl::class.java.name
+    val containerName = "$annName\$Container"
+    fun annotated(ci: io.github.classgraph.ClassInfo) =
+      ci.hasAnnotation(annName) || ci.hasAnnotation(containerName) ||
+        ci.methodInfo.any { it.hasAnnotation(annName) || it.hasAnnotation(containerName) }
+
+    return ClassGraph()
+      .enableClassInfo()
+      .enableMethodInfo()
+      .enableAnnotationInfo()
+      .acceptPackages("com.sarastarquant.kioskops.sdk")
+      .scan()
+      .use { scan -> scan.allClasses.filter(::annotated).flatMap { entriesFor(it.loadClass()) } }
+  }
+
+  private fun entriesFor(cls: Class<*>): List<Entry> {
+    val ann = ComplianceControl::class.java
+    val classLevel = cls.getAnnotationsByType(ann).map { Entry(it.framework, it.control, cls.simpleName) }
+    val methodLevel = cls.declaredMethods.flatMap { m ->
+      m.getAnnotationsByType(ann).map { Entry(it.framework, it.control, "${cls.simpleName}.${m.name}") }
+    }
+    return classLevel + methodLevel
+  }
+
+  private fun render(entries: List<Entry>): String {
+    val byControl = entries
+      .groupBy { it.framework to it.control }
+      .toSortedMap(compareBy({ it.first }, { it.second }))
+
+    val sb = StringBuilder()
+    sb.append("# Compliance control traceability\n\n")
+    sb.append("Generated from `@ComplianceControl` annotations by `ComplianceTraceabilityTest`.\n")
+    sb.append("Do not edit by hand; run `./gradlew :kiosk-ops-sdk:testDebugUnitTest -Pcompliance.update` to regenerate.\n\n")
+    sb.append("| Framework | Control | Verified by |\n")
+    sb.append("|-----------|---------|-------------|\n")
+    for ((key, rows) in byControl) {
+      val tests = rows.map { it.test }.toSortedSet().joinToString("; ")
+      sb.append("| ${key.first} | ${key.second} | $tests |\n")
+    }
+    return sb.toString()
+  }
+}

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/FipsComplianceCheckerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/FipsComplianceCheckerTest.kt
@@ -14,6 +14,7 @@ import org.robolectric.RobolectricTestRunner
 class FipsComplianceCheckerTest {
 
   @Test
+  @ComplianceControl(framework = "NIST SP 800-171", control = "3.13.11")
   fun `check returns result with provider info`() {
     val status = FipsComplianceChecker.check()
     // On standard JVM/Robolectric, FIPS mode is not active

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/RetentionEnforcerTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/compliance/RetentionEnforcerTest.kt
@@ -5,7 +5,9 @@ import org.junit.Test
 
 class RetentionEnforcerTest {
 
-  @Test fun `maximalist defaults include 365 day minimum audit retention`() {
+  @Test
+  @ComplianceControl(framework = "NIST SP 800-171", control = "3.3.1")
+  fun `maximalist defaults include 365 day minimum audit retention`() {
     val policy = RetentionPolicy.maximalistDefaults()
     assertThat(policy.minimumAuditRetentionDays).isEqualTo(365)
   }

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/AesGcmKatTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/AesGcmKatTest.kt
@@ -6,6 +6,7 @@
 package com.sarastarquant.kioskops.sdk.crypto
 
 import com.google.common.truth.Truth.assertThat
+import com.sarastarquant.kioskops.sdk.compliance.ComplianceControl
 import javax.crypto.AEADBadTagException
 import javax.crypto.spec.SecretKeySpec
 import org.junit.Test
@@ -21,6 +22,7 @@ import org.junit.Test
  * not merely that the JDK ships a working AES. The Keystore-backed key path
  * itself requires hardware and is exercised by instrumented tests.
  */
+@ComplianceControl(framework = "NIST SP 800-171", control = "3.13.11")
 class AesGcmKatTest {
 
   // GCM spec Test Case 13: 256-bit zero key, zero IV, empty plaintext.

--- a/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/Pbkdf2KatTest.kt
+++ b/kiosk-ops-sdk/src/test/java/com/sarastarquant/kioskops/sdk/crypto/Pbkdf2KatTest.kt
@@ -6,6 +6,7 @@
 package com.sarastarquant.kioskops.sdk.crypto
 
 import com.google.common.truth.Truth.assertThat
+import com.sarastarquant.kioskops.sdk.compliance.ComplianceControl
 import org.junit.Test
 
 /**
@@ -19,6 +20,7 @@ import org.junit.Test
  * SHA-256 vectors: the widely cited PBKDF2-HMAC-SHA256 vectors for
  * password="password", salt="salt".
  */
+@ComplianceControl(framework = "NIST SP 800-171", control = "3.13.11")
 class Pbkdf2KatTest {
 
   @Test


### PR DESCRIPTION
## Summary

The compliance mapping documents asserted control coverage in prose, with nothing connecting a control to an executable test. This change links controls to the tests that enforce them and generates a CI-verified traceability matrix.

## Changes

- Add a `@ComplianceControl(framework, control)` test annotation and apply it to the tests that enforce each control (the AES-256-GCM and PBKDF2 known-answer tests, the FIPS checker test, the audit-retention test, and the `cuiDefaults` preset test).
- `ComplianceTraceabilityTest` generates `docs/compliance/traceability.md` from those annotations under `-Pcompliance.update`, and otherwise verifies it. The build fails if the committed matrix drifts, or if an annotation cites a control its framework document does not list.
- Link the NIST mapping document to the generated matrix.

## Notes

This mirrors the repo's existing generate-then-verify pattern (the `.api` binary-compat file and the detekt baseline work the same way); the test does not write into the repo except under the explicit update flag.

Scope is honest: only controls the SDK enforces technically get a backing test. Controls owned by the host application or the organization stay out of scope and keep their existing prose notes. Initial coverage maps NIST SP 800-171 3.3.1 and 3.13.11; more frameworks can register as their enforcing tests gain annotations.

## Verification

`./gradlew :kiosk-ops-sdk:testDebugUnitTest :kiosk-ops-sdk:detekt :kiosk-ops-sdk:koverVerifyDebug` passes. Injecting a control id absent from the NIST document fails the guard; restoring it passes.
