### PR TITLE
bump jackson and wire build-tooling to patched versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,22 @@ subprojects {
       if (requested.group == "io.netty") {
         useVersion("4.1.135.Final")
       }
+      // jackson arrives only via the Dokka generator runtime (doc build); absent
+      // from releaseRuntimeClasspath, never in the AAR. Pin the whole jackson
+      // stack (not just databind) so the modules stay aligned, which jackson
+      // requires. 2.18.8 is the latest 2.18.x and clears GHSA-hgj6-7826-r7m5,
+      // GHSA-rmj7-2vxq-3g9f, and GHSA-j3rv-43j4-c7qm. GHSA-5jmj-h7xm-6q6v (the old
+      // polymorphic-deserialization advisory) has no published fix and does not
+      // apply here: Dokka does not enable default typing on untrusted input.
+      if (requested.group.startsWith("com.fasterxml.jackson")) {
+        useVersion("2.18.8")
+      }
+      // wire-runtime arrives only via androidx.benchmark tooling (test/benchmark
+      // module; never in the AAR). Pin the whole group so wire-runtime and its
+      // -jvm variant stay aligned. 6.3.0 fixes GHSA-7xpr-hc2w-34m9.
+      if (requested.group == "com.squareup.wire") {
+        useVersion("6.3.0")
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Bumps two build-tooling transitives to patched versions to clear open Dependabot alerts. Neither is in `releaseRuntimeClasspath` or the published AAR, so the SDK and its consumers were never affected.

- `jackson` stack to `2.18.8` (pulled in by the Dokka HTML generator runtime). Clears GHSA-hgj6-7826-r7m5, GHSA-rmj7-2vxq-3g9f, GHSA-j3rv-43j4-c7qm. Pins the whole `com.fasterxml.jackson` group so the modules stay aligned.
- `com.squareup.wire` to `6.3.0` (pulled in by `androidx.benchmark`). Clears GHSA-7xpr-hc2w-34m9.

GHSA-5jmj-h7xm-6q6v has no published fix in the 2.18.x or 2.21.x line and does not apply here; Dokka does not enable default typing on untrusted input.

## Verification

- `:kiosk-ops-sdk:dokkaGeneratePublicationHtml` builds with jackson 2.18.8.
- `releaseRuntimeClasspath` contains neither jackson nor wire.
