### PR TITLE
release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
-
-- The `kioskops-bom` Maven BOM. It constrained a single artifact, so it added publish complexity and
-  consumer ceremony with no version-alignment value. Depend on `kiosk-ops-sdk` directly. A BOM can
-  return additively if the SDK ever splits into multiple co-versioned artifacts.
+## [1.4.0] - 2026-06-24
 
 ### Fixed
 
@@ -19,6 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (and any config that enables `encryptDatabase`) loaded the SQLCipher factory by reflection but never
   called `System.loadLibrary("sqlcipher")`. The SDK now loads the native library before use. Consumers
   using database encryption must depend on `net.zetetic:sqlcipher-android`; see `docs/sample-app.md`.
+
+### Added
+
+- On-device reliability suite that boots the SDK under every compliance preset and runs the queue,
+  encrypted-database, sync, and data-rights flows on an emulator. It gates pull requests and caught the
+  encryption crash above.
+- ClusterFuzzLite continuous fuzzing for the payload codec, on pull requests and a weekly batch.
+
+### Removed
+
+- The `kioskops-bom` Maven BOM. It constrained a single artifact, so it added publish complexity and
+  consumer ceremony with no version-alignment value. Depend on `kiosk-ops-sdk` directly. A BOM can
+  return additively if the SDK ever splits into multiple co-versioned artifacts.
 
 ## [1.3.1] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.3.1")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.4.0")
 }
 ```
 
@@ -55,7 +55,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.3.1")
+    implementation("com.sarastarquant.kioskops:kiosk-ops-sdk:1.4.0")
 }
 ```
 
@@ -71,7 +71,7 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.3.1")
+    implementation("com.github.sara-star-quant:KioskOps-SDK-Android-Enterprise:v1.4.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ kotlin.code.style=official
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 # SDK Version
-VERSION_NAME=1.3.1
+VERSION_NAME=1.4.0


### PR DESCRIPTION
## Summary

This is the release PR for v1.4.0, a reliability and security release. It bumps `VERSION_NAME` from 1.3.1 to 1.4.0, updates the install snippets in the README, and moves the accumulated `Unreleased` changelog entries under a dated `1.4.0` heading.

## What ships in 1.4.0

- Fixed the database-encryption crash that hit `cuiDefaults()` and any config with `encryptDatabase` enabled. The SDK loaded the SQLCipher factory by reflection but never called `System.loadLibrary("sqlcipher")`, so the first database open failed with `UnsatisfiedLinkError`. The SDK now loads the native library before use.
- Added an on-device reliability suite that boots the SDK under every compliance preset and exercises the queue, encrypted-database, sync, and data-rights flows on an emulator. It gates pull requests and is what caught the encryption crash.
- Added ClusterFuzzLite continuous fuzzing for the payload codec, running on pull requests and a weekly batch.
- Removed the single-artifact `kioskops-bom`. Consumers depend on `kiosk-ops-sdk` directly.
- Pinned the jackson and wire build-tooling dependencies off open advisories. These are already on `main`; they never ship in the AAR.

## Release steps after merge

1. Tag `v1.4.0` on the merge commit and push the tag.
2. Run the Release workflow with `tag=v1.4.0`.
3. Verify the published artifact on Maven Central.
